### PR TITLE
Allow using integrated GPU to play videos, fix #18.

### DIFF
--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -173,5 +173,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -97,11 +97,13 @@ class VideoView: NSOpenGLView {
       UInt32(NSOpenGLPFADoubleBuffer),
       UInt32(NSOpenGLPFAAccelerated),
       UInt32(NSOpenGLPFAOpenGLProfile), UInt32(NSOpenGLProfileVersion3_2Core),
+      UInt32(NSOpenGLPFAAllowOfflineRenderers), // allows integrated gpu to be used
       0
     ]
     let desentAttributes: [NSOpenGLPixelFormatAttribute] = [
       UInt32(NSOpenGLPFADoubleBuffer),
       UInt32(NSOpenGLPFAOpenGLProfile), UInt32(NSOpenGLProfileVersion3_2Core),
+      UInt32(NSOpenGLPFAAllowOfflineRenderers),
       0
     ]
     


### PR DESCRIPTION
Some older cards may not support this but this works for me on mid-2012 rMBP.