### PR TITLE
Fix the wrong ObjectID

### DIFF
--- a/iina/zh-Hans.lproj/PrefSubViewController.strings
+++ b/iina/zh-Hans.lproj/PrefSubViewController.strings
@@ -116,4 +116,5 @@
 /* Class = "NSMenuItem"; title = "Right"; ObjectID = "zLl-vV-p1h"; */
 "zLl-vV-p1h.title" = "右";
 
-"Q02-3C-Ho6.title" = "自动下载字幕来源:";
+/* Class = "NSTextFieldCell"; title = "Download subtitles from:"; ObjectID = "MiO-eP-c1f"; */
+"MiO-eP-c1f.title" = "自动下载字幕来源:";


### PR DESCRIPTION
- ObjectID of “Download subtitles from:” is wrong in the localization
  file.

Also a friendly ping to @shilch, it seems you missed this label 😃 