### PR TITLE
Fix the label moving problem.

### DIFF
--- a/iina/DurationDisplayTextField.swift
+++ b/iina/DurationDisplayTextField.swift
@@ -33,7 +33,7 @@ class DurationDisplayTextField: NSTextField {
     let stringValue: String
     switch mode {
     case .duration:
-      stringValue = duration.stringRepresentation
+      stringValue = " \(duration.stringRepresentation)"
     case .remaining:
       let remaining = duration - current
       stringValue = "-\(remaining.stringRepresentation)"


### PR DESCRIPTION
 Add a placeholder ' ' to make the number stable. Refer to QuickTime. Problem found in #284.