### PR TITLE
Fix #241

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -11,9 +11,6 @@ import Foundation
 
 fileprivate typealias PK = Preference.Key
 
-fileprivate let yes_str = "yes"
-fileprivate let no_str = "no"
-
 // Global functions
 
 protocol MPVEventDelegate {
@@ -775,7 +772,9 @@ class MPVController: NSObject {
 
     case .bool:
       let value = ud.bool(forKey: key)
-      code = mpv_set_option_string(mpv, name, value ? yes_str : no_str)
+      let yesStr = "yes"
+      let noStr = "no"
+      code = mpv_set_option_string(mpv, name, value ? yesStr : noStr)
 
     case .string:
       let value = ud.string(forKey: key)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It fixes issue #241 .

---

**Description:**
Original `fileprivate let no_str` seems be revised to an empty C string. So actually `mpv_set_option_string` send nothing when value is false.