### PR TITLE
Add Document Icon Button, AutoLayout Quick Settings

### DIFF
--- a/iina/AboutWindowController.swift
+++ b/iina/AboutWindowController.swift
@@ -16,6 +16,13 @@ class AboutWindowController: NSWindowController {
 
 
   @IBOutlet weak var iconImageView: NSImageView!
+  @IBOutlet weak var iinaLabel: NSTextField! {
+    didSet {
+      if #available(OSX 10.11, *) {
+        iinaLabel.font = NSFont.systemFont(ofSize: 24, weight: NSFontWeightLight)
+      }
+    }
+  }
   @IBOutlet weak var versionLabel: NSTextField!
   @IBOutlet weak var mpvVersionLabel: NSTextField!
   @IBOutlet var detailTextView: NSTextView!

--- a/iina/Base.lproj/AboutWindowController.xib
+++ b/iina/Base.lproj/AboutWindowController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12113" systemVersion="16E175b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12113"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,14 +21,14 @@
         <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="460" height="389"/>
+            <rect key="contentRect" x="196" y="240" width="460" height="498"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="460" height="480"/>
+                <rect key="frame" x="0.0" y="0.0" width="460" height="498"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1qX-fa-Cpb">
-                        <rect key="frame" x="205" y="343" width="51" height="29"/>
+                        <rect key="frame" x="204" y="361" width="53" height="29"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="IINA" id="dkA-td-UyX">
                             <font key="font" metaFont="system" size="24"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -36,7 +36,7 @@
                         </textFieldCell>
                     </textField>
                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4mA-gM-aUl">
-                        <rect key="frame" x="190" y="380" width="80" height="80"/>
+                        <rect key="frame" x="190" y="398" width="80" height="80"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="80" id="KkK-2b-CPd"/>
                             <constraint firstAttribute="height" constant="80" id="qsl-wW-Kqu"/>
@@ -44,7 +44,7 @@
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="GO3-iS-dzs"/>
                     </imageView>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bR2-NT-yUx">
-                        <rect key="frame" x="212" y="318" width="36" height="17"/>
+                        <rect key="frame" x="212" y="336" width="36" height="17"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0.0.1" id="gZA-85-Zaw">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -52,7 +52,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nXJ-o9-ufd">
-                        <rect key="frame" x="200" y="296" width="60" height="14"/>
+                        <rect key="frame" x="200" y="314" width="60" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="mpv 0.0.0" id="ZAx-ah-fbZ">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -60,7 +60,7 @@
                         </textFieldCell>
                     </textField>
                     <box boxType="custom" borderWidth="0.0" cornerRadius="6" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="igW-n0-W0W">
-                        <rect key="frame" x="20" y="210" width="420" height="70"/>
+                        <rect key="frame" x="20" y="228" width="420" height="70"/>
                         <view key="contentView" id="4zp-K9-MTB">
                             <rect key="frame" x="0.0" y="0.0" width="420" height="70"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -85,18 +85,17 @@
                         <color key="fillColor" red="1" green="0.75326818612585023" blue="0.73013206403877551" alpha="1" colorSpace="calibratedRGB"/>
                         <font key="titleFont" size="9" name=".AppleSystemUIFont"/>
                     </box>
-                    <scrollView wantsLayer="YES" fixedFrame="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2q-cR-Rly">
-                        <rect key="frame" x="20" y="20" width="420" height="170"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="9n1-qG-jVw">
-                            <rect key="frame" x="0.0" y="0.0" width="420" height="170"/>
+                    <scrollView wantsLayer="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2q-cR-Rly">
+                        <rect key="frame" x="20" y="20" width="420" height="188"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="9n1-qG-jVw">
+                            <rect key="frame" x="0.0" y="0.0" width="420" height="188"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <textView ambiguous="YES" editable="NO" drawsBackground="NO" importsGraphics="NO" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="qhB-2z-pCF">
-                                    <rect key="frame" x="0.0" y="-1" width="420" height="170"/>
+                                <textView editable="NO" drawsBackground="NO" importsGraphics="NO" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="qhB-2z-pCF">
+                                    <rect key="frame" x="0.0" y="-1" width="420" height="188"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="420" height="170"/>
+                                    <size key="minSize" width="420" height="188"/>
                                     <size key="maxSize" width="463" height="10000000"/>
                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 </textView>
@@ -108,7 +107,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="iiz-lw-07s">
-                            <rect key="frame" x="404" y="0.0" width="16" height="170"/>
+                            <rect key="frame" x="404" y="0.0" width="16" height="188"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
@@ -118,19 +117,23 @@
                     <constraint firstItem="bR2-NT-yUx" firstAttribute="top" secondItem="1qX-fa-Cpb" secondAttribute="bottom" constant="8" id="AIX-Zs-1ih"/>
                     <constraint firstItem="nXJ-o9-ufd" firstAttribute="top" secondItem="bR2-NT-yUx" secondAttribute="bottom" constant="8" id="Bh9-CF-DfG"/>
                     <constraint firstItem="4mA-gM-aUl" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="DHi-VV-ssz"/>
+                    <constraint firstAttribute="trailing" secondItem="t2q-cR-Rly" secondAttribute="trailing" constant="20" id="FlV-ec-kBi"/>
                     <constraint firstItem="nXJ-o9-ufd" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="Gyx-43-4kD"/>
                     <constraint firstItem="bR2-NT-yUx" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="K1k-Is-gsx"/>
+                    <constraint firstItem="t2q-cR-Rly" firstAttribute="top" secondItem="igW-n0-W0W" secondAttribute="bottom" constant="20" id="SMy-jd-0QB"/>
+                    <constraint firstAttribute="bottom" secondItem="t2q-cR-Rly" secondAttribute="bottom" constant="20" id="XVM-j8-yZo"/>
                     <constraint firstItem="igW-n0-W0W" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="ZIe-bX-RwH"/>
                     <constraint firstItem="4mA-gM-aUl" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="20" id="bnv-SY-41o"/>
                     <constraint firstItem="1qX-fa-Cpb" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="enk-7t-JV8"/>
                     <constraint firstItem="igW-n0-W0W" firstAttribute="top" secondItem="bR2-NT-yUx" secondAttribute="bottom" constant="38" id="kBe-ej-J3Z"/>
+                    <constraint firstItem="t2q-cR-Rly" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="qeQ-h0-kHV"/>
                     <constraint firstItem="1qX-fa-Cpb" firstAttribute="top" secondItem="4mA-gM-aUl" secondAttribute="bottom" constant="8" id="zeR-yY-x4j"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="101" y="240"/>
+            <point key="canvasLocation" x="101" y="294"/>
         </window>
     </objects>
 </document>

--- a/iina/Base.lproj/AboutWindowController.xib
+++ b/iina/Base.lproj/AboutWindowController.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
-        <capability name="system font weights other than Regular or Bold" minToolsVersion="7.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AboutWindowController" customModule="IINA" customModuleProvider="target">
             <connections>
                 <outlet property="detailTextView" destination="qhB-2z-pCF" id="fQr-u5-rXZ"/>
                 <outlet property="iconImageView" destination="4mA-gM-aUl" id="NPA-GO-34B"/>
+                <outlet property="iinaLabel" destination="1qX-fa-Cpb" id="QCx-gY-Nyv"/>
                 <outlet property="mpvVersionLabel" destination="nXJ-o9-ufd" id="o50-IN-SqE"/>
                 <outlet property="versionLabel" destination="bR2-NT-yUx" id="jNq-4u-fPh"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
@@ -21,8 +21,8 @@
         <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="460" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="contentRect" x="196" y="240" width="460" height="389"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="460" height="480"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -30,7 +30,7 @@
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1qX-fa-Cpb">
                         <rect key="frame" x="205" y="343" width="51" height="29"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="IINA" id="dkA-td-UyX">
-                            <font key="font" metaFont="systemLight" size="24"/>
+                            <font key="font" metaFont="system" size="24"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>

--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E154a" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,7 +34,6 @@
                 <outlet property="sideBarWidthConstraint" destination="1BL-aP-tHS" id="Qbw-L4-DAp"/>
                 <outlet property="timePreviewWhenSeek" destination="qOq-6a-7j7" id="ngM-1f-G5D"/>
                 <outlet property="titleBarView" destination="TRx-2V-Gr3" id="kOU-nP-MAP"/>
-                <outlet property="titleTextField" destination="gW1-BG-OEa" id="8wO-J1-Yp6"/>
                 <outlet property="volumeSlider" destination="SAG-kc-FAt" id="zM0-Gg-vfy"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
@@ -44,7 +43,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="680" height="355"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="680" height="355"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -64,24 +63,6 @@
                         <constraints>
                             <constraint firstItem="pxV-jX-kfL" firstAttribute="centerX" secondItem="Nrz-jZ-Luf" secondAttribute="centerX" id="1zk-hi-hE0"/>
                             <constraint firstItem="pxV-jX-kfL" firstAttribute="centerY" secondItem="Nrz-jZ-Luf" secondAttribute="centerY" id="GGt-bx-91X"/>
-                        </constraints>
-                    </visualEffectView>
-                    <visualEffectView wantsLayer="YES" appearanceType="vibrantDark" blendingMode="withinWindow" material="dark" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="TRx-2V-Gr3">
-                        <rect key="frame" x="0.0" y="333" width="680" height="22"/>
-                        <subviews>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-BG-OEa">
-                                <rect key="frame" x="323" y="3" width="35" height="17"/>
-                                <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Title" usesSingleLineMode="YES" id="AOe-dk-iFa">
-                                    <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                        </subviews>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="22" id="1Dw-Bg-FRS"/>
-                            <constraint firstItem="gW1-BG-OEa" firstAttribute="centerY" secondItem="TRx-2V-Gr3" secondAttribute="centerY" id="Ns9-95-wyP"/>
-                            <constraint firstItem="gW1-BG-OEa" firstAttribute="centerX" secondItem="TRx-2V-Gr3" secondAttribute="centerX" id="Rg9-VR-z4c"/>
                         </constraints>
                     </visualEffectView>
                     <visualEffectView wantsLayer="YES" appearanceType="vibrantDark" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" blendingMode="withinWindow" material="dark" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="OiF-pA-8Sd" userLabel="Control Bar" customClass="ControlBarView" customModule="IINA" customModuleProvider="target">
@@ -276,6 +257,12 @@
                         <shadow key="shadow" blurRadius="12">
                             <color key="color" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
                         </shadow>
+                    </visualEffectView>
+                    <visualEffectView wantsLayer="YES" appearanceType="vibrantDark" blendingMode="withinWindow" material="dark" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="TRx-2V-Gr3">
+                        <rect key="frame" x="0.0" y="333" width="680" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="22" id="1Dw-Bg-FRS"/>
+                        </constraints>
                     </visualEffectView>
                     <visualEffectView hidden="YES" wantsLayer="YES" appearanceType="vibrantDark" blendingMode="withinWindow" material="dark" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="g0O-v5-RQj">
                         <rect key="frame" x="8" y="277" width="197" height="48"/>

--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -69,10 +70,7 @@
                         <rect key="frame" x="0.0" y="333" width="680" height="22"/>
                         <subviews>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gW1-BG-OEa">
-                                <rect key="frame" x="78" y="2" width="524" height="18"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="18" id="Mcr-JX-OZE"/>
-                                </constraints>
+                                <rect key="frame" x="323" y="3" width="35" height="17"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" truncatesLastVisibleLine="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Title" usesSingleLineMode="YES" id="AOe-dk-iFa">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -82,10 +80,8 @@
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="height" constant="22" id="1Dw-Bg-FRS"/>
-                            <constraint firstItem="gW1-BG-OEa" firstAttribute="leading" secondItem="TRx-2V-Gr3" secondAttribute="leading" constant="80" id="5N2-2O-X7D"/>
-                            <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gW1-BG-OEa" secondAttribute="trailing" constant="80" id="Rpp-hW-yLy"/>
-                            <constraint firstItem="gW1-BG-OEa" firstAttribute="top" secondItem="TRx-2V-Gr3" secondAttribute="top" constant="2" id="Ti8-YH-IOe"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gW1-BG-OEa" secondAttribute="trailing" constant="19" id="cT5-1h-pRJ"/>
+                            <constraint firstItem="gW1-BG-OEa" firstAttribute="centerY" secondItem="TRx-2V-Gr3" secondAttribute="centerY" id="Ns9-95-wyP"/>
+                            <constraint firstItem="gW1-BG-OEa" firstAttribute="centerX" secondItem="TRx-2V-Gr3" secondAttribute="centerX" id="Rg9-VR-z4c"/>
                         </constraints>
                     </visualEffectView>
                     <visualEffectView wantsLayer="YES" appearanceType="vibrantDark" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" blendingMode="withinWindow" material="dark" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="OiF-pA-8Sd" userLabel="Control Bar" customClass="ControlBarView" customModule="IINA" customModuleProvider="target">
@@ -110,11 +106,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Yg9-Sd-sWy" userLabel="Left Button Label">
-                                <rect key="frame" x="121" y="39" width="32" height="12"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="28" id="FZL-et-vym"/>
-                                    <constraint firstAttribute="height" constant="12" id="dwX-4g-cIG"/>
-                                </constraints>
+                                <rect key="frame" x="126" y="38" width="27" height="13"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="-32x" id="eCe-SS-Wlj">
                                     <font key="font" metaFont="system" size="10"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -138,8 +130,8 @@
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="EIi-qd-glM" userLabel="Right Button">
                                 <rect key="frame" x="257" y="33" width="24" height="24"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" secondItem="EIi-qd-glM" secondAttribute="height" multiplier="1:1" id="3Wl-xU-eqe"/>
                                     <constraint firstAttribute="width" constant="24" id="KMp-bQ-6E5"/>
-                                    <constraint firstAttribute="height" constant="24" id="jMe-zC-CIx"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="speed" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" maxAcceleratorLevel="5" id="Aiu-eh-hd9">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES" multiLevelAccelerator="YES"/>
@@ -153,7 +145,7 @@
                                 <rect key="frame" x="159" y="33" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="2E4-Ht-wMT"/>
-                                    <constraint firstAttribute="height" constant="24" id="EMj-8F-Sxr"/>
+                                    <constraint firstAttribute="width" secondItem="10x-bg-xlj" secondAttribute="height" multiplier="1:1" id="h3a-98-udy"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="speedl" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" maxAcceleratorLevel="5" id="ijT-3Y-AK2">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES" multiLevelAccelerator="YES"/>
@@ -164,11 +156,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="QTI-wi-oyB" userLabel="Right Button Label">
-                                <rect key="frame" x="287" y="39" width="32" height="12"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="12" id="rn3-Sw-gl7"/>
-                                    <constraint firstAttribute="width" constant="28" id="ygE-Mh-HRU"/>
-                                </constraints>
+                                <rect key="frame" x="287" y="38" width="22" height="13"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="32x" id="ULE-u4-k9L">
                                     <font key="font" metaFont="system" size="10"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -179,7 +167,7 @@
                                 <rect key="frame" x="379" y="33" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="FBK-0C-gcn"/>
-                                    <constraint firstAttribute="height" constant="24" id="nWg-Z7-Zhc"/>
+                                    <constraint firstAttribute="width" secondItem="YvW-zG-QiW" secondAttribute="height" multiplier="1:1" id="aob-OL-eIh"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="center" alternateImage="NSActionTemplate" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="tPP-JA-L7s">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -203,8 +191,8 @@
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="gxw-pJ-Lcg">
                                 <rect key="frame" x="208" y="33" width="24" height="24"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" secondItem="gxw-pJ-Lcg" secondAttribute="height" multiplier="1:1" id="7Xg-CL-HXe"/>
                                     <constraint firstAttribute="width" constant="24" id="7xv-qQ-n43"/>
-                                    <constraint firstAttribute="height" constant="24" id="wi7-Km-eiK"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="play" imagePosition="only" alignment="center" alternateImage="pause" refusesFirstResponder="YES" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="mWQ-R0-GGr">
                                     <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
@@ -227,7 +215,7 @@
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wy6-h4-fsN">
                                 <rect key="frame" x="405" y="33" width="24" height="24"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="24" id="Rv3-oS-0Hu"/>
+                                    <constraint firstAttribute="width" secondItem="wy6-h4-fsN" secondAttribute="height" multiplier="1:1" id="q4R-Lz-Nkb"/>
                                     <constraint firstAttribute="width" constant="24" id="yzN-B1-5gA"/>
                                 </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="playlist" imagePosition="only" alignment="center" alternateImage="playlist" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="ZPD-PJ-11g">
@@ -249,34 +237,35 @@
                             </textField>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="EIi-qd-glM" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="10" id="19J-AW-dth"/>
+                            <constraint firstItem="Yg9-Sd-sWy" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="3hp-cg-tce"/>
+                            <constraint firstItem="SAG-kc-FAt" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="57O-as-xWb"/>
                             <constraint firstItem="wy6-h4-fsN" firstAttribute="leading" secondItem="YvW-zG-QiW" secondAttribute="trailing" constant="2" id="6uo-LX-tAd"/>
                             <constraint firstItem="NBD-MV-OuG" firstAttribute="leading" secondItem="OiF-pA-8Sd" secondAttribute="leading" constant="2" id="72g-fy-o5h"/>
-                            <constraint firstAttribute="bottom" secondItem="NBD-MV-OuG" secondAttribute="bottom" constant="10" id="7Jy-5x-USp"/>
+                            <constraint firstItem="YvW-zG-QiW" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="7D5-Pm-dax"/>
                             <constraint firstItem="gxw-pJ-Lcg" firstAttribute="leading" secondItem="10x-bg-xlj" secondAttribute="trailing" constant="25" id="C5Q-BE-NQl"/>
                             <constraint firstItem="gxw-pJ-Lcg" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="10" id="CBt-v9-IKk"/>
                             <constraint firstItem="SAG-kc-FAt" firstAttribute="leading" secondItem="2py-h1-0km" secondAttribute="trailing" constant="6" id="D7r-1r-RAg"/>
                             <constraint firstItem="2py-h1-0km" firstAttribute="leading" secondItem="OiF-pA-8Sd" secondAttribute="leading" constant="12" id="G5q-Ix-iSL"/>
-                            <constraint firstAttribute="bottom" secondItem="GgV-Cc-sk0" secondAttribute="bottom" constant="10" id="JVf-zk-FZE"/>
-                            <constraint firstItem="Yg9-Sd-sWy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SAG-kc-FAt" secondAttribute="trailing" constant="8" id="JZb-uM-l66"/>
                             <constraint firstAttribute="trailing" secondItem="wy6-h4-fsN" secondAttribute="trailing" constant="11" id="N38-df-Pr9"/>
                             <constraint firstItem="gxw-pJ-Lcg" firstAttribute="centerX" secondItem="OiF-pA-8Sd" secondAttribute="centerX" id="Omt-FZ-m1d"/>
-                            <constraint firstItem="Yg9-Sd-sWy" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="16" id="V3q-eS-4TC"/>
+                            <constraint firstItem="wy6-h4-fsN" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="StJ-z5-GZc"/>
+                            <constraint firstItem="gxw-pJ-Lcg" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="VYo-Nd-4U8"/>
+                            <constraint firstItem="eBP-6g-bAT" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="aoS-uC-xZV"/>
                             <constraint firstItem="10x-bg-xlj" firstAttribute="leading" secondItem="Yg9-Sd-sWy" secondAttribute="trailing" constant="8" id="bH4-gR-KzH"/>
                             <constraint firstItem="EIi-qd-glM" firstAttribute="leading" secondItem="gxw-pJ-Lcg" secondAttribute="trailing" constant="25" id="cJT-Pe-szx"/>
                             <constraint firstItem="GgV-Cc-sk0" firstAttribute="leading" secondItem="eBP-6g-bAT" secondAttribute="trailing" constant="2" id="exB-rF-Yot"/>
+                            <constraint firstItem="QTI-wi-oyB" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="fP2-Xu-NtF"/>
                             <constraint firstAttribute="width" constant="440" id="g1S-BA-95v"/>
                             <constraint firstItem="eBP-6g-bAT" firstAttribute="leading" secondItem="NBD-MV-OuG" secondAttribute="trailing" constant="2" id="g5q-vC-OGb"/>
                             <constraint firstAttribute="height" constant="67" id="g84-xP-093"/>
-                            <constraint firstItem="QTI-wi-oyB" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="16" id="jS2-YP-VdM"/>
+                            <constraint firstItem="EIi-qd-glM" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="hAH-Wz-qOP"/>
+                            <constraint firstItem="GgV-Cc-sk0" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="iNg-Yd-cYq"/>
                             <constraint firstAttribute="bottom" secondItem="eBP-6g-bAT" secondAttribute="bottom" constant="9" id="lGU-KV-JXB"/>
-                            <constraint firstItem="wy6-h4-fsN" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="10" id="ltp-E1-fer"/>
+                            <constraint firstItem="eBP-6g-bAT" firstAttribute="centerX" secondItem="OiF-pA-8Sd" secondAttribute="centerX" id="lmN-8M-XOP"/>
+                            <constraint firstItem="10x-bg-xlj" firstAttribute="centerY" secondItem="2py-h1-0km" secondAttribute="centerY" id="pwm-Tw-Rs3"/>
                             <constraint firstItem="10x-bg-xlj" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="10" id="qQu-WW-eR6"/>
                             <constraint firstItem="QTI-wi-oyB" firstAttribute="leading" secondItem="EIi-qd-glM" secondAttribute="trailing" constant="8" id="r1a-G2-I1e"/>
                             <constraint firstAttribute="trailing" secondItem="GgV-Cc-sk0" secondAttribute="trailing" constant="2" id="sgJ-oR-QEJ"/>
-                            <constraint firstItem="SAG-kc-FAt" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="16" id="wIg-92-XDQ"/>
-                            <constraint firstItem="YvW-zG-QiW" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="10" id="wnr-6p-18l"/>
-                            <constraint firstItem="2py-h1-0km" firstAttribute="top" secondItem="OiF-pA-8Sd" secondAttribute="top" constant="12" id="wuk-mx-e29"/>
                         </constraints>
                     </visualEffectView>
                     <visualEffectView wantsLayer="YES" appearanceType="vibrantDark" blendingMode="withinWindow" material="appearanceBased" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="epo-S6-QVB" userLabel="SideBar">
@@ -317,17 +306,14 @@
                         <rect key="frame" x="260" y="130" width="160" height="96"/>
                         <subviews>
                             <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="uZe-PA-1Id">
-                                <rect key="frame" x="64" y="44" width="32" height="32"/>
+                                <rect key="frame" x="64" y="45" width="32" height="32"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" secondItem="uZe-PA-1Id" secondAttribute="height" multiplier="1:1" id="2KD-iY-Rbo"/>
                                     <constraint firstAttribute="width" constant="32" id="7BK-Wc-K9S"/>
-                                    <constraint firstAttribute="height" constant="32" id="7n9-7n-g3H"/>
                                 </constraints>
                             </progressIndicator>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2gH-wF-EpI">
-                                <rect key="frame" x="6" y="20" width="148" height="17"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="17" id="yt3-1K-dDJ"/>
-                                </constraints>
+                                <rect key="frame" x="24" y="20" width="112" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Buffering... 100%" id="3fe-fP-yMB">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -335,10 +321,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hlZ-5D-Wag">
-                                <rect key="frame" x="6" y="8" width="148" height="11"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="11" id="zg3-Qp-YfX"/>
-                                </constraints>
+                                <rect key="frame" x="64" y="8" width="32" height="11"/>
                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="WOE-SX-krh">
                                     <font key="font" metaFont="miniSystem"/>
                                     <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -348,15 +331,13 @@
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="hlZ-5D-Wag" secondAttribute="bottom" constant="8" id="DDG-Yw-RfA"/>
-                            <constraint firstItem="hlZ-5D-Wag" firstAttribute="leading" secondItem="oX4-0N-but" secondAttribute="leading" constant="8" id="Pie-eY-Ftg"/>
+                            <constraint firstItem="2gH-wF-EpI" firstAttribute="centerX" secondItem="oX4-0N-but" secondAttribute="centerX" id="Nfu-GM-Wcw"/>
                             <constraint firstItem="uZe-PA-1Id" firstAttribute="centerX" secondItem="oX4-0N-but" secondAttribute="centerX" id="Qfn-MA-rHy"/>
-                            <constraint firstItem="2gH-wF-EpI" firstAttribute="leading" secondItem="oX4-0N-but" secondAttribute="leading" constant="8" id="RLx-4b-Scw"/>
-                            <constraint firstAttribute="trailing" secondItem="hlZ-5D-Wag" secondAttribute="trailing" constant="8" id="W3A-Hg-brL"/>
-                            <constraint firstAttribute="trailing" secondItem="2gH-wF-EpI" secondAttribute="trailing" constant="8" id="dDH-ph-Yex"/>
+                            <constraint firstItem="hlZ-5D-Wag" firstAttribute="centerX" secondItem="oX4-0N-but" secondAttribute="centerX" id="bOz-TB-YLY"/>
                             <constraint firstAttribute="bottom" secondItem="2gH-wF-EpI" secondAttribute="bottom" constant="20" id="ddz-PD-RB3"/>
-                            <constraint firstAttribute="height" constant="96" id="djw-BU-Feb"/>
                             <constraint firstAttribute="width" constant="160" id="ehe-F5-vKu"/>
                             <constraint firstItem="uZe-PA-1Id" firstAttribute="top" secondItem="oX4-0N-but" secondAttribute="top" constant="20" id="sio-TN-E1P"/>
+                            <constraint firstItem="2gH-wF-EpI" firstAttribute="top" secondItem="uZe-PA-1Id" secondAttribute="bottom" constant="8" id="swz-Rz-9Hv"/>
                         </constraints>
                     </visualEffectView>
                 </subviews>

--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PlaylistViewController" customModule="IINA" customModuleProvider="target">
             <connections>
+                <outlet property="buttonTopConstraint" destination="hLh-Or-ZUd" id="wDU-9e-scd"/>
                 <outlet property="chapterTableView" destination="BvG-MR-6LX" id="WoF-Wg-fqX"/>
                 <outlet property="chaptersBtn" destination="SOR-3l-PFj" id="W2q-tm-TA0"/>
                 <outlet property="deleteBtn" destination="7my-AM-8Ts" id="wTg-jz-wRa"/>
@@ -294,9 +295,6 @@
                 </tabView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
                     <rect key="frame" x="120" y="321" width="120" height="48"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="48" id="BRL-lK-4tg"/>
-                    </constraints>
                     <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -321,15 +319,17 @@
             </subviews>
             <constraints>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="5Zq-JQ-XO4" secondAttribute="bottom" id="EOu-Jc-A7S"/>
-                <constraint firstItem="5Zq-JQ-XO4" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="LDc-wa-R0O"/>
                 <constraint firstAttribute="bottom" secondItem="Yym-Zw-Hd8" secondAttribute="bottom" id="VEC-3U-YTI"/>
                 <constraint firstAttribute="trailing" secondItem="Yym-Zw-Hd8" secondAttribute="trailing" id="Wu2-Mo-8NM"/>
                 <constraint firstAttribute="trailing" secondItem="SOR-3l-PFj" secondAttribute="trailing" id="atA-b5-vwd"/>
-                <constraint firstItem="SOR-3l-PFj" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="b6J-nd-u9K"/>
+                <constraint firstAttribute="width" constant="240" id="clJ-Nh-tAc"/>
                 <constraint firstItem="5Zq-JQ-XO4" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="elP-iu-vPl"/>
                 <constraint firstItem="5Zq-JQ-XO4" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" multiplier="0.5" id="epQ-jC-a0B"/>
+                <constraint firstItem="5Zq-JQ-XO4" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="hLh-Or-ZUd"/>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="iKz-2C-iJv"/>
+                <constraint firstItem="SOR-3l-PFj" firstAttribute="top" secondItem="5Zq-JQ-XO4" secondAttribute="top" id="iZK-4D-ROr"/>
                 <constraint firstItem="SOR-3l-PFj" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" multiplier="0.5" id="owL-kO-fvO"/>
+                <constraint firstItem="SOR-3l-PFj" firstAttribute="height" secondItem="5Zq-JQ-XO4" secondAttribute="height" id="sRW-ep-6n7"/>
             </constraints>
             <point key="canvasLocation" x="150" y="217.5"/>
         </customView>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12113" systemVersion="16E175b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12113"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -65,13 +65,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="360" height="791"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="841"/>
             <subviews>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB">
-                    <rect key="frame" x="0.0" y="740" width="360" height="5"/>
+                    <rect key="frame" x="0.0" y="790" width="360" height="5"/>
                 </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb">
-                    <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="360" id="aeh-Vh-Ufo"/>
                     </constraints>
@@ -79,17 +79,17 @@
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A">
                             <view key="view" id="NRI-ba-KMd">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT">
-                                        <rect key="frame" x="0.0" y="0.0" width="373" height="743"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="373" height="793"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf">
-                                            <rect key="frame" x="0.0" y="0.0" width="373" height="743"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="373" height="793"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="76" width="373" height="667"/>
+                                                    <rect key="frame" x="0.0" y="126" width="373" height="667"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950">
                                                             <rect key="frame" x="0.0" y="0.0" width="373" height="667"/>
@@ -150,7 +150,7 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
                                                                     <rect key="frame" x="18" y="630" width="83" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -174,7 +174,7 @@
                                                                         <action selector="aspectChangedAction:" target="-2" id="U7C-TJ-2UJ"/>
                                                                     </connections>
                                                                 </segmentedControl>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
                                                                     <rect key="frame" x="17" y="509" width="323" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aspect Ratio:" id="YgL-iV-bca">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -182,7 +182,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
+                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
                                                                     <rect key="frame" x="295" y="480" width="58" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="58" id="6bj-r1-RIj"/>
@@ -196,7 +196,7 @@
                                                                         <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
                                                                     <rect key="frame" x="18" y="441" width="322" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -230,7 +230,7 @@
                                                                         <action selector="cropChangedAction:" target="-2" id="1Go-JW-6R4"/>
                                                                     </connections>
                                                                 </segmentedControl>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
                                                                     <rect key="frame" x="17" y="373" width="64" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -263,7 +263,7 @@
                                                                         <action selector="speedChangedAction:" target="-2" id="asr-iq-ZNJ"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="91" y="293" width="34" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1.00x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
                                                                         <font key="font" metaFont="system" size="10"/>
@@ -271,7 +271,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
                                                                     <rect key="frame" x="18" y="305" width="322" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -279,7 +279,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
+                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
                                                                     <rect key="frame" x="285" y="273" width="57" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="57" id="Ood-Jd-gLJ"/>
@@ -306,7 +306,7 @@
                                                                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IWj-Dg-ZDI">
                                                                     <rect key="frame" x="0.0" y="194" width="373" height="5"/>
                                                                 </box>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
                                                                     <rect key="frame" x="17" y="155" width="323" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="Xez-sb-mfB">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -321,7 +321,7 @@
                                                                         <action selector="equalizerSliderAction:" target="-2" id="bF8-qZ-hks"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
                                                                     <rect key="frame" x="18" y="121" width="76" height="14"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="72" id="TvH-N9-GfJ"/>
@@ -339,7 +339,7 @@
                                                                         <action selector="equalizerSliderAction:" target="-2" id="Mtl-BL-VYs"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
                                                                     <rect key="frame" x="18" y="96" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="eDl-Si-LSa">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -354,7 +354,7 @@
                                                                         <action selector="equalizerSliderAction:" target="-2" id="64F-Yg-BY8"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
                                                                     <rect key="frame" x="18" y="71" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Rky-lo-Buu">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -369,7 +369,7 @@
                                                                         <action selector="equalizerSliderAction:" target="-2" id="h5f-VW-qGS"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
                                                                     <rect key="frame" x="18" y="46" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="r6x-z0-oFC">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -384,7 +384,7 @@
                                                                         <action selector="equalizerSliderAction:" target="-2" id="b6L-ZX-hlF"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
                                                                     <rect key="frame" x="18" y="21" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="eLh-fu-pMj">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -465,7 +465,7 @@
                                                                 <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="T29-ww-YfA">
                                                                     <rect key="frame" x="21" y="262" width="254" height="11"/>
                                                                     <beginningViews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
                                                                             <rect key="frame" x="-2" y="0.0" width="29" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -476,7 +476,7 @@
                                                                         <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uaf-dz-Gf9">
                                                                             <rect key="frame" x="25" y="0.0" width="184" height="11"/>
                                                                         </customView>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
                                                                             <rect key="frame" x="207" y="0.0" width="18" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -487,7 +487,7 @@
                                                                         <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bae-lI-CIE">
                                                                             <rect key="frame" x="223" y="0.0" width="0.0" height="11"/>
                                                                         </customView>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
                                                                             <rect key="frame" x="221" y="0.0" width="19" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -498,7 +498,7 @@
                                                                         <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VSq-CL-JCl">
                                                                             <rect key="frame" x="238" y="0.0" width="0.0" height="11"/>
                                                                         </customView>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
                                                                             <rect key="frame" x="236" y="0.0" width="20" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -530,7 +530,7 @@
                                                                         <real value="3.4028234663852886e+38"/>
                                                                     </customSpacing>
                                                                 </stackView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
                                                                     <rect key="frame" x="344" y="276" width="11" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="x" id="W7H-mU-v3D">
                                                                         <font key="font" metaFont="system"/>
@@ -652,7 +652,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
-                                            <rect key="frame" x="357" y="0.0" width="16" height="743"/>
+                                            <rect key="frame" x="357" y="0.0" width="16" height="793"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -667,23 +667,23 @@
                         </tabViewItem>
                         <tabViewItem label="Audio" identifier="2" id="bzk-c2-LH5">
                             <view key="view" id="Dxl-wa-zgc">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="267" width="360" height="476"/>
+                                                    <rect key="frame" x="0.0" y="291" width="360" height="502"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="476"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="502"/>
                                                             <subviews>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
-                                                                    <rect key="frame" x="17" y="439" width="83" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
+                                                                    <rect key="frame" x="17" y="465" width="83" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio track:" id="x39-62-7KC">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -691,10 +691,10 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS">
-                                                                    <rect key="frame" x="0.0" y="355" width="360" height="76"/>
+                                                                    <rect key="frame" x="0.0" y="381" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="FLg-2m-Zaq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
@@ -756,15 +756,15 @@
                                                                         <action selector="audioDelayChangedAction:" target="-2" id="egE-eN-9bo"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
-                                                                    <rect key="frame" x="18" y="318" width="101" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
+                                                                    <rect key="frame" x="18" y="344" width="101" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="doa-7T-eeK">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="doa-7T-eeK">
                                                                     <rect key="frame" x="18" y="226" width="20" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs">
                                                                         <font key="font" metaFont="miniSystem"/>
@@ -772,7 +772,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kF3-Ee-Pha">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kF3-Ee-Pha">
                                                                     <rect key="frame" x="247" y="226" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="5s" id="C0t-gm-Tim">
                                                                         <font key="font" metaFont="miniSystem"/>
@@ -780,7 +780,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
                                                                     <rect key="frame" x="130" y="226" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="wgA-op-JP4">
                                                                         <font key="font" metaFont="miniSystem"/>
@@ -788,7 +788,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0DM-CY-o8W" userLabel="Delay">
+                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0DM-CY-o8W" userLabel="Delay">
                                                                     <rect key="frame" x="276" y="236" width="64" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="64" id="Alb-o2-pM2"/>
@@ -803,7 +803,7 @@
                                                                         <action selector="customAudioDelayEditFinishedAction:" target="-2" id="if3-IB-m6c"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
                                                                     <rect key="frame" x="17" y="278" width="310" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio delay:" id="AKs-VQ-fKF">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -811,7 +811,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gR7-cS-zmu" userLabel="Speed Slider Indicator">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gR7-cS-zmu" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="134" y="257" width="29" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0.0s" usesSingleLineMode="YES" id="s3F-Tl-Siy">
                                                                         <font key="font" metaFont="system" size="10"/>
@@ -822,7 +822,7 @@
                                                                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
                                                                     <rect key="frame" x="0.0" y="201" width="360" height="5"/>
                                                                 </box>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I">
                                                                     <rect key="frame" x="18" y="168" width="64" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="iS4-Zr-9Ig">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -846,7 +846,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
                                                                                             <rect key="frame" x="-2" y="0.0" width="32" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -865,10 +865,10 @@
                                                                                     </customSpacing>
                                                                                 </stackView>
                                                                                 <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sHK-zw-tFa">
-                                                                                    <rect key="frame" x="28" y="0.0" width="59" height="140"/>
+                                                                                    <rect key="frame" x="28" y="0.0" width="0.0" height="140"/>
                                                                                 </customView>
                                                                                 <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e12-8n-EpU">
-                                                                                    <rect key="frame" x="87" y="0.0" width="24" height="140"/>
+                                                                                    <rect key="frame" x="28" y="0.0" width="24" height="140"/>
                                                                                     <beginningViews>
                                                                                         <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
                                                                                             <rect key="frame" x="3.5" y="18" width="18" height="122"/>
@@ -877,7 +877,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
                                                                                             <rect key="frame" x="-2" y="0.0" width="28" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -896,10 +896,10 @@
                                                                                     </customSpacing>
                                                                                 </stackView>
                                                                                 <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ccm-o6-iBe">
-                                                                                    <rect key="frame" x="111" y="0.0" width="0.0" height="140"/>
+                                                                                    <rect key="frame" x="52" y="0.0" width="0.0" height="140"/>
                                                                                 </customView>
                                                                                 <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Vo-in-EfA">
-                                                                                    <rect key="frame" x="111" y="0.0" width="20" height="140"/>
+                                                                                    <rect key="frame" x="52" y="0.0" width="20" height="140"/>
                                                                                     <beginningViews>
                                                                                         <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
                                                                                             <rect key="frame" x="1.5" y="18" width="18" height="122"/>
@@ -908,7 +908,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
                                                                                             <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -927,7 +927,7 @@
                                                                                     </customSpacing>
                                                                                 </stackView>
                                                                                 <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UFW-iM-FFP">
-                                                                                    <rect key="frame" x="131" y="0.0" width="0.0" height="140"/>
+                                                                                    <rect key="frame" x="72" y="0.0" width="59" height="140"/>
                                                                                 </customView>
                                                                                 <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uEN-an-lH8">
                                                                                     <rect key="frame" x="131" y="0.0" width="22" height="140"/>
@@ -939,7 +939,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
                                                                                             <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -970,7 +970,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
                                                                                             <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1001,7 +1001,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
                                                                                             <rect key="frame" x="-0.5" y="0.0" width="18" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1032,7 +1032,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
                                                                                             <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1063,7 +1063,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
                                                                                             <rect key="frame" x="-1.5" y="0.0" width="20" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1094,7 +1094,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
                                                                                             <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1125,7 +1125,7 @@
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
                                                                                             <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1200,7 +1200,7 @@
                                                                         <stackView orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="FqD-Ht-R76">
                                                                             <rect key="frame" x="303" y="20" width="37" height="112"/>
                                                                             <beginningViews>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
                                                                                     <rect key="frame" x="-2" y="98" width="41" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+12 dB" id="4BZ-H1-GEU">
                                                                                         <font key="font" metaFont="smallSystem"/>
@@ -1211,7 +1211,7 @@
                                                                                 <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ixi-lk-2aY">
                                                                                     <rect key="frame" x="0.0" y="28" width="37" height="70"/>
                                                                                 </customView>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
                                                                                     <rect key="frame" x="-2" y="14" width="29" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0 dB" id="lBn-YS-jL7">
                                                                                         <font key="font" metaFont="smallSystem"/>
@@ -1222,7 +1222,7 @@
                                                                                 <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QXY-J5-Bxa">
                                                                                     <rect key="frame" x="0.0" y="14" width="37" height="0.0"/>
                                                                                 </customView>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
                                                                                     <rect key="frame" x="-2" y="0.0" width="39" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-12 dB" id="Lpw-ws-Ezh">
                                                                                         <font key="font" metaFont="smallSystem"/>
@@ -1276,7 +1276,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
-                                                                    <rect key="frame" x="119" y="308" width="209" height="32"/>
+                                                                    <rect key="frame" x="14" y="308" width="332" height="32"/>
                                                                     <buttonCell key="cell" type="push" title="Load External Audio Track..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8Ax-5X-osl">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -1300,10 +1300,10 @@
                                                                 <constraint firstItem="0DM-CY-o8W" firstAttribute="centerY" secondItem="a7T-nr-ELY" secondAttribute="centerY" constant="-1" id="B5R-Ja-IjZ"/>
                                                                 <constraint firstItem="a7T-nr-ELY" firstAttribute="top" secondItem="gR7-cS-zmu" secondAttribute="bottom" constant="2" id="C2d-F4-WIg"/>
                                                                 <constraint firstItem="doa-7T-eeK" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="FFk-YH-GZp"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="8" id="GKm-PJ-l72"/>
                                                                 <constraint firstItem="C39-jO-zwp" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="GZM-yD-gvm"/>
                                                                 <constraint firstAttribute="trailing" secondItem="KKr-0Y-831" secondAttribute="trailing" id="HbW-t2-Z43"/>
                                                                 <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="LQR-09-ikh"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="leading" secondItem="kvu-fg-olx" secondAttribute="trailing" constant="8" id="Mco-hj-MHE"/>
                                                                 <constraint firstItem="a7T-nr-ELY" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="Mj2-sZ-AFW"/>
                                                                 <constraint firstAttribute="trailing" secondItem="0DM-CY-o8W" secondAttribute="trailing" constant="20" id="PGx-UC-O1P"/>
                                                                 <constraint firstItem="kF3-Ee-Pha" firstAttribute="trailing" secondItem="a7T-nr-ELY" secondAttribute="trailing" id="PJ2-pg-wRS"/>
@@ -1311,8 +1311,9 @@
                                                                 <constraint firstItem="C39-jO-zwp" firstAttribute="centerX" secondItem="a7T-nr-ELY" secondAttribute="centerX" id="Pq3-Ff-F3F"/>
                                                                 <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="18" id="Q61-jq-LnT"/>
                                                                 <constraint firstItem="dB1-5J-5YU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IHl-Ks-v7I" secondAttribute="trailing" constant="8" id="QNN-mu-WjM"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XdF-fV-DCz" secondAttribute="trailing" constant="20" id="Qgj-tE-Ji4"/>
+                                                                <constraint firstAttribute="trailing" secondItem="XdF-fV-DCz" secondAttribute="trailing" constant="20" id="Qgj-tE-Ji4"/>
                                                                 <constraint firstItem="Qal-0X-4kS" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="SwW-S7-LX2"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="Xww-D3-qlU"/>
                                                                 <constraint firstItem="dB1-5J-5YU" firstAttribute="centerY" secondItem="IHl-Ks-v7I" secondAttribute="centerY" id="Ym6-Rk-xwx"/>
                                                                 <constraint firstItem="PLF-x4-bMC" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="dRT-Ri-a9H"/>
                                                                 <constraint firstItem="E4v-kh-61H" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="f6t-BV-Nqr"/>
@@ -1324,7 +1325,6 @@
                                                                 <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="20" id="pbW-gp-age"/>
                                                                 <constraint firstAttribute="trailing" secondItem="ZPW-fz-5Oi" secondAttribute="trailing" constant="35" id="tRW-zx-YUE"/>
                                                                 <constraint firstItem="kvu-fg-olx" firstAttribute="top" secondItem="Qal-0X-4kS" secondAttribute="bottom" constant="20" id="wOv-GA-HuD"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="baseline" secondItem="kvu-fg-olx" secondAttribute="baseline" id="xfb-DC-Nak"/>
                                                                 <constraint firstItem="PLF-x4-bMC" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="8" id="zPs-Z3-aNL"/>
                                                             </constraints>
                                                         </customView>
@@ -1345,11 +1345,11 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE">
-                                            <rect key="frame" x="0.0" y="727" width="360" height="16"/>
+                                            <rect key="frame" x="0.0" y="777" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="17z-n6-rH9">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="743"/>
+                                            <rect key="frame" x="344" y="0.0" width="16" height="793"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1364,26 +1364,26 @@
                         </tabViewItem>
                         <tabViewItem label="Subtitles" identifier="3" id="jND-MZ-sKB">
                             <view key="view" id="MrM-2b-7ob">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="793"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                                    <rect key="frame" x="0.0" y="-23" width="360" height="816"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="Sub Basic">
-                                                            <rect key="frame" x="0.0" y="352" width="360" height="391"/>
+                                                            <rect key="frame" x="0.0" y="399" width="360" height="417"/>
                                                             <subviews>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh">
-                                                                    <rect key="frame" x="0.0" y="274" width="360" height="72"/>
+                                                                    <rect key="frame" x="0.0" y="300" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="2vU-hm-gGB">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1436,10 +1436,10 @@
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg">
-                                                                    <rect key="frame" x="0.0" y="157" width="360" height="72"/>
+                                                                    <rect key="frame" x="0.0" y="183" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="Jve-qX-Agy">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1491,24 +1491,24 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
-                                                                    <rect key="frame" x="18" y="354" width="60" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
+                                                                    <rect key="frame" x="18" y="380" width="60" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Subtitle">
-                                                                    <rect key="frame" x="18" y="237" width="131" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Subtitle">
+                                                                    <rect key="frame" x="18" y="263" width="131" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="Sub Delay">
-                                                                    <rect key="frame" x="17" y="120" width="123" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="Sub Delay">
+                                                                    <rect key="frame" x="17" y="146" width="123" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External subtitles:" id="RA1-fF-OrB">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1528,7 +1528,7 @@
                                                                 <stackView orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="feR-n9-dpN">
                                                                     <rect key="frame" x="20" y="27" width="248" height="11"/>
                                                                     <beginningViews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
                                                                             <rect key="frame" x="-2" y="0.0" width="20" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1537,10 +1537,10 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P2D-Jk-ikd">
-                                                                            <rect key="frame" x="24" y="0.0" width="168" height="11"/>
+                                                                            <rect key="frame" x="24" y="0.0" width="0.0" height="11"/>
                                                                         </customView>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                            <rect key="frame" x="198" y="0.0" width="19" height="11"/>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
+                                                                            <rect key="frame" x="30" y="0.0" width="19" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
                                                                                 <font key="font" metaFont="miniSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1548,9 +1548,9 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JTL-na-jiR">
-                                                                            <rect key="frame" x="223" y="0.0" width="0.0" height="11"/>
+                                                                            <rect key="frame" x="55" y="0.0" width="168" height="11"/>
                                                                         </customView>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
                                                                             <rect key="frame" x="229" y="0.0" width="21" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1577,7 +1577,7 @@
                                                                         <real value="3.4028234663852886e+38"/>
                                                                     </customSpacing>
                                                                 </stackView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="Speed Slider Indicator">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="138" y="58" width="29" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0.0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
                                                                         <font key="font" metaFont="system" size="10"/>
@@ -1585,7 +1585,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
                                                                     <rect key="frame" x="18" y="80" width="98" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -1593,7 +1593,7 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="Delay">
+                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="Delay">
                                                                     <rect key="frame" x="276" y="39" width="64" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="64" id="ptd-kK-aWm"/>
@@ -1609,7 +1609,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SpJ-zD-xUM">
-                                                                    <rect key="frame" x="140" y="110" width="138" height="32"/>
+                                                                    <rect key="frame" x="14" y="110" width="332" height="32"/>
                                                                     <buttonCell key="cell" type="push" title="Load Subtitles..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="C97-zJ-O3Y">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -1623,9 +1623,9 @@
                                                                 <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
                                                                 <constraint firstAttribute="trailing" secondItem="eOz-bB-vzM" secondAttribute="trailing" constant="20" id="1wg-zP-XSs"/>
+                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="4bp-rl-zyR"/>
                                                                 <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="55g-oO-gXc"/>
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="22" id="Axq-IW-PvK"/>
-                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="baseline" secondItem="M2U-rq-X2L" secondAttribute="baseline" id="B12-HB-9kN"/>
                                                                 <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="SpJ-zD-xUM" secondAttribute="bottom" constant="20" id="BDg-f0-TgZ"/>
                                                                 <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="C4V-Gw-CZp"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="20" id="CWa-3H-hWP"/>
@@ -1633,14 +1633,14 @@
                                                                 <constraint firstItem="feR-n9-dpN" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Dw8-uh-I71"/>
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" id="Fdp-D4-VPU"/>
                                                                 <constraint firstItem="feR-n9-dpN" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="2" id="GGQ-nC-HEr"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SpJ-zD-xUM" secondAttribute="trailing" constant="20" id="HwV-jO-qIQ"/>
+                                                                <constraint firstAttribute="trailing" secondItem="SpJ-zD-xUM" secondAttribute="trailing" constant="20" id="HwV-jO-qIQ"/>
                                                                 <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
                                                                 <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
                                                                 <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
                                                                 <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="O5J-FT-DtN"/>
+                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="SKu-Hk-5mJ"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cOv-Yl-KdH" secondAttribute="trailing" constant="20" id="SRy-t5-N0K"/>
-                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="leading" secondItem="M2U-rq-X2L" secondAttribute="trailing" constant="8" id="Uba-r0-f5X"/>
                                                                 <constraint firstItem="M2U-rq-X2L" firstAttribute="top" secondItem="LMp-7Y-Rxg" secondAttribute="bottom" constant="20" id="Y58-bK-q43"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="8" id="hl3-X4-nod"/>
@@ -1654,16 +1654,16 @@
                                                             </constraints>
                                                         </customView>
                                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jRc-VZ-Vv2">
-                                                            <rect key="frame" x="0.0" y="350" width="360" height="5"/>
+                                                            <rect key="frame" x="0.0" y="397" width="360" height="5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="W2h-DQ-cHB"/>
                                                             </constraints>
                                                         </box>
                                                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSw-NK-ZU6" userLabel="Sub Style">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="352"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="399"/>
                                                             <subviews>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
-                                                                    <rect key="frame" x="18" y="267" width="44" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
+                                                                    <rect key="frame" x="18" y="314" width="44" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scale:" id="Wbx-Ti-qiS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1671,13 +1671,13 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B8f-KH-BaO">
-                                                                    <rect key="frame" x="66" y="266" width="252" height="19"/>
+                                                                    <rect key="frame" x="18" y="289" width="324" height="19"/>
                                                                     <sliderCell key="cell" continuous="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="above" sliderType="linear" id="Qpw-NH-Unh"/>
                                                                     <connections>
                                                                         <action selector="subScaleSliderAction:" target="-2" id="zEB-hd-cz8"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
                                                                     <rect key="frame" x="17" y="206" width="73" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Style:" id="ZBd-13-lA1">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -1685,8 +1685,8 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR">
-                                                                    <rect key="frame" x="18" y="304" width="324" height="28"/>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR">
+                                                                    <rect key="frame" x="18" y="351" width="324" height="28"/>
                                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sub style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1733,7 +1733,7 @@
                                                                                 <action selector="subTextSizeAction:" target="-2" id="Z3b-cC-c1V"/>
                                                                             </connections>
                                                                         </popUpButton>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
                                                                             <rect key="frame" x="18" y="116" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="6LO-6y-IsA">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -1741,7 +1741,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
                                                                             <rect key="frame" x="112" y="116" width="30" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Size:" id="s9l-Hb-SCk">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -1749,7 +1749,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
                                                                             <rect key="frame" x="18" y="92" width="324" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BORDER" id="GlZ-YU-dNm">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
@@ -1757,7 +1757,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
                                                                             <rect key="frame" x="18" y="68" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="ANn-CR-JOV">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -1765,7 +1765,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kaq-YT-MxI">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kaq-YT-MxI">
                                                                             <rect key="frame" x="18" y="20" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="3kI-6i-ujt">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -1773,7 +1773,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
                                                                             <rect key="frame" x="103" y="68" width="39" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Width:" id="22j-ra-GAY">
                                                                                 <font key="font" metaFont="smallSystem"/>
@@ -1803,7 +1803,7 @@
                                                                                 <action selector="subTextBgColorAction:" target="-2" id="hoQ-1z-12N"/>
                                                                             </connections>
                                                                         </colorWell>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
                                                                             <rect key="frame" x="18" y="44" width="86" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BACKGROUND" id="uqb-mz-A22">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
@@ -1811,7 +1811,7 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
                                                                             <rect key="frame" x="18" y="140" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FONT" id="g6B-DC-lJ0">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
@@ -1896,7 +1896,7 @@
                                                                     </constraints>
                                                                 </customView>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
-                                                                    <rect key="frame" x="324" y="267" width="16" height="16"/>
+                                                                    <rect key="frame" x="324" y="314" width="16" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" secondItem="8ZC-Wx-nt7" secondAttribute="height" multiplier="1:1" id="6H8-an-kzq"/>
                                                                         <constraint firstAttribute="width" constant="16" id="RJ8-MW-Hsw"/>
@@ -1909,8 +1909,8 @@
                                                                         <action selector="subScaleReset:" target="-2" id="wfC-aE-U04"/>
                                                                     </connections>
                                                                 </button>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
-                                                                    <rect key="frame" x="18" y="243" width="61" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
+                                                                    <rect key="frame" x="18" y="266" width="61" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Position:" id="t03-36-Zge">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1918,7 +1918,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lzW-d6-Asr">
-                                                                    <rect key="frame" x="83" y="242" width="259" height="19"/>
+                                                                    <rect key="frame" x="18" y="241" width="324" height="19"/>
                                                                     <sliderCell key="cell" continuous="YES" alignment="left" maxValue="100" doubleValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
                                                                     <connections>
                                                                         <action selector="subPosSliderAction:" target="-2" id="Top-XW-i2A"/>
@@ -1928,24 +1928,24 @@
                                                             <constraints>
                                                                 <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="6Qf-qa-Ysv"/>
                                                                 <constraint firstItem="XwE-7y-DXJ" firstAttribute="top" secondItem="ipr-WR-eax" secondAttribute="bottom" constant="8" id="6Vb-CZ-GSt"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="OEX-Gn-xCa" secondAttribute="trailing" constant="8" id="Dgm-Mh-AUv"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="centerY" secondItem="OEX-Gn-xCa" secondAttribute="centerY" id="FE1-hy-EJm"/>
-                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="centerY" secondItem="B8f-KH-BaO" secondAttribute="centerY" id="Gtd-Mh-QTJ"/>
-                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="leading" secondItem="B8f-KH-BaO" secondAttribute="trailing" constant="8" id="Ifo-NK-ckJ"/>
+                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="centerY" secondItem="9xm-5m-Q7G" secondAttribute="centerY" id="ACk-wM-3n6"/>
+                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="CYZ-OZ-8LN"/>
+                                                                <constraint firstAttribute="trailing" secondItem="B8f-KH-BaO" secondAttribute="trailing" constant="20" id="EXr-k6-yGD"/>
+                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="top" secondItem="9xm-5m-Q7G" secondAttribute="bottom" constant="8" id="Ep0-ly-4hM"/>
                                                                 <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="Ilc-HK-W4o"/>
                                                                 <constraint firstAttribute="trailing" secondItem="XwE-7y-DXJ" secondAttribute="trailing" id="J4W-zE-0MD"/>
                                                                 <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="Muz-yO-mxR"/>
                                                                 <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" id="ND0-4i-wgI"/>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="20" id="VGa-k1-zby"/>
                                                                 <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="aHP-HN-SEj"/>
                                                                 <constraint firstItem="Lkf-Yn-nsR" firstAttribute="top" secondItem="gSw-NK-ZU6" secondAttribute="top" constant="20" id="atW-bb-cRk"/>
                                                                 <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="20" id="bXP-av-Tgw"/>
+                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="cc5-R8-qHE"/>
                                                                 <constraint firstItem="XwE-7y-DXJ" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" id="d2Y-xa-MBE"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="8" id="fOu-zY-3I4"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="8" id="ifV-0X-iXU"/>
                                                                 <constraint firstAttribute="bottom" secondItem="XwE-7y-DXJ" secondAttribute="bottom" constant="24" id="jg3-w0-k4p"/>
                                                                 <constraint firstAttribute="trailing" secondItem="lzW-d6-Asr" secondAttribute="trailing" constant="20" id="kIM-Hc-R7X"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="centerY" secondItem="9xm-5m-Q7G" secondAttribute="centerY" id="m8i-yQ-trv"/>
+                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="8" id="pBA-vr-zFa"/>
+                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="20" id="sZZ-fS-slr"/>
+                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="8" id="vZu-j8-Sbx"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="20" id="vrO-Og-xsG"/>
                                                                 <constraint firstAttribute="trailing" secondItem="Lkf-Yn-nsR" secondAttribute="trailing" constant="20" id="xXr-Uq-KGI"/>
                                                             </constraints>
@@ -1973,11 +1973,11 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="jEt-nA-sGO">
-                                            <rect key="frame" x="0.0" y="727" width="360" height="16"/>
+                                            <rect key="frame" x="0.0" y="777" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3ZS-ug-kkq">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="743"/>
+                                        <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="3ZS-ug-kkq">
+                                            <rect key="frame" x="344" y="0.0" width="16" height="793"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1993,7 +1993,7 @@
                     </tabViewItems>
                 </tabView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw">
-                    <rect key="frame" x="0.0" y="743" width="120.5" height="48"/>
+                    <rect key="frame" x="0.0" y="793" width="120.5" height="48"/>
                     <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
@@ -2003,7 +2003,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK">
-                    <rect key="frame" x="120" y="743" width="120.5" height="48"/>
+                    <rect key="frame" x="120" y="793" width="120.5" height="48"/>
                     <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2013,7 +2013,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc">
-                    <rect key="frame" x="240" y="743" width="120" height="48"/>
+                    <rect key="frame" x="240" y="793" width="120" height="48"/>
                     <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2044,7 +2044,7 @@
                 <constraint firstItem="rH3-pU-mFc" firstAttribute="leading" secondItem="3Fk-ey-FhK" secondAttribute="trailing" id="zbP-4C-atO"/>
                 <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="3Fk-ey-FhK" secondAttribute="bottom" id="zzU-O5-6j9"/>
             </constraints>
-            <point key="canvasLocation" x="2782" y="149.5"/>
+            <point key="canvasLocation" x="2782" y="174.5"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+        <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QuickSettingViewController" customModule="IINA" customModuleProvider="target">
             <connections>
                 <outlet property="aspectSegment" destination="Ljl-w6-gIf" id="X3Q-8g-q0e"/>
+                <outlet property="audioDelaySlider" destination="a7T-nr-ELY" id="jkQ-Z9-GfO"/>
+                <outlet property="audioDelaySliderConstraint" destination="fRb-Oo-uXF" id="ATv-F6-EG7"/>
                 <outlet property="audioDelaySliderIndicator" destination="gR7-cS-zmu" id="4Zq-bk-Nxd"/>
                 <outlet property="audioEqSlider1" destination="pHR-ym-VeQ" id="Chq-ra-A3e"/>
                 <outlet property="audioEqSlider10" destination="w04-h5-qaz" id="hRO-UH-FuK"/>
@@ -35,7 +40,10 @@
                 <outlet property="saturationSlider" destination="qeO-tk-I0D" id="uDF-fx-afd"/>
                 <outlet property="secSubTableView" destination="Jve-qX-Agy" id="0ia-bh-sbu"/>
                 <outlet property="speedSlider" destination="UWh-M9-5Nw" id="UXr-dD-8K1"/>
+                <outlet property="speedSliderConstraint" destination="E1b-GU-FYc" id="G0O-eJ-JRu"/>
                 <outlet property="speedSliderIndicator" destination="3EN-WD-QNI" id="flo-Hs-pTQ"/>
+                <outlet property="subDelaySlider" destination="dXz-x4-sm5" id="hFa-oi-ZD5"/>
+                <outlet property="subDelaySliderConstraint" destination="tSt-6x-AfJ" id="AUE-YW-MUm"/>
                 <outlet property="subDelaySliderIndicator" destination="VdJ-nq-zaM" id="0uy-Jw-eKf"/>
                 <outlet property="subPosSlider" destination="lzW-d6-Asr" id="4n0-Xj-8qN"/>
                 <outlet property="subScaleResetBtn" destination="8ZC-Wx-nt7" id="fK9-bQ-Mxl"/>
@@ -57,68 +65,37 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="360" height="871"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="791"/>
             <subviews>
-                <button verticalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK">
-                    <rect key="frame" x="120" y="823" width="120" height="48"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="tabBtnAction:" target="-2" id="mLi-M9-gbN"/>
-                    </connections>
-                </button>
-                <button verticalHuggingPriority="750" fixedFrame="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc">
-                    <rect key="frame" x="240" y="823" width="120" height="48"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="tabBtnAction:" target="-2" id="IEz-WA-p4g"/>
-                    </connections>
-                </button>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw">
-                    <rect key="frame" x="0.0" y="823" width="120" height="48"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
-                        <font key="font" metaFont="systemBold"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="tabBtnAction:" target="-2" id="T17-c3-4hp"/>
-                    </connections>
-                </button>
-                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB">
-                    <rect key="frame" x="0.0" y="820" width="360" height="5"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB">
+                    <rect key="frame" x="0.0" y="740" width="360" height="5"/>
                 </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb">
-                    <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="360" id="aeh-Vh-Ufo"/>
+                    </constraints>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A">
                             <view key="view" id="NRI-ba-KMd">
-                                <rect key="frame" x="0.0" y="0.0" width="373" height="789"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT">
-                                        <rect key="frame" x="0.0" y="0.0" width="373" height="789"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="373" height="743"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf">
-                                            <rect key="frame" x="0.0" y="0.0" width="373" height="789"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="373" height="743"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="103" width="373" height="686"/>
+                                                    <rect key="frame" x="0.0" y="76" width="373" height="667"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950">
-                                                            <rect key="frame" x="0.0" y="0.0" width="373" height="686"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="373" height="667"/>
                                                             <subviews>
                                                                 <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D">
-                                                                    <rect key="frame" x="0.0" y="565" width="373" height="76"/>
+                                                                    <rect key="frame" x="0.0" y="546" width="373" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="373" height="76"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -174,7 +151,7 @@
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
-                                                                    <rect key="frame" x="17" y="649" width="323" height="17"/>
+                                                                    <rect key="frame" x="18" y="630" width="83" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -182,7 +159,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf">
-                                                                    <rect key="frame" x="18" y="497" width="256" height="24"/>
+                                                                    <rect key="frame" x="18" y="478" width="256" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="cMu-YF-riv">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -198,7 +175,7 @@
                                                                     </connections>
                                                                 </segmentedControl>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
-                                                                    <rect key="frame" x="17" y="528" width="323" height="17"/>
+                                                                    <rect key="frame" x="17" y="509" width="323" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aspect Ratio:" id="YgL-iV-bca">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -206,7 +183,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
-                                                                    <rect key="frame" x="295" y="499" width="58" height="22"/>
+                                                                    <rect key="frame" x="295" y="480" width="58" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="58" id="6bj-r1-RIj"/>
                                                                     </constraints>
@@ -220,7 +197,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
-                                                                    <rect key="frame" x="17" y="460" width="323" height="17"/>
+                                                                    <rect key="frame" x="18" y="441" width="322" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -228,7 +205,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="720" translatesAutoresizingMaskIntoConstraints="NO" id="ItN-JT-puN">
-                                                                    <rect key="frame" x="260" y="424" width="99" height="32"/>
+                                                                    <rect key="frame" x="260" y="405" width="99" height="32"/>
                                                                     <buttonCell key="cell" type="push" title="Custom..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vFD-HU-RVz">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -238,7 +215,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kUi-hW-BR6">
-                                                                    <rect key="frame" x="18" y="429" width="242" height="24"/>
+                                                                    <rect key="frame" x="18" y="410" width="242" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="iuN-rN-jT7">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -254,7 +231,7 @@
                                                                     </connections>
                                                                 </segmentedControl>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
-                                                                    <rect key="frame" x="17" y="392" width="323" height="17"/>
+                                                                    <rect key="frame" x="17" y="373" width="64" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -262,7 +239,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE">
-                                                                    <rect key="frame" x="18" y="361" width="182" height="24"/>
+                                                                    <rect key="frame" x="18" y="342" width="182" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -276,34 +253,10 @@
                                                                         <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
                                                                     </connections>
                                                                 </segmentedControl>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
-                                                                    <rect key="frame" x="86" y="279" width="33" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14" id="ScZ-Cn-Mii"/>
-                                                                        <constraint firstAttribute="width" constant="29" id="jTV-Rn-1kx"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
-                                                                    <rect key="frame" x="159" y="279" width="33" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="29" id="MKA-EY-Efw"/>
-                                                                        <constraint firstAttribute="height" constant="14" id="o61-Y0-WoJ"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw">
-                                                                    <rect key="frame" x="21" y="294" width="236" height="18"/>
+                                                                    <rect key="frame" x="21" y="275" width="254" height="18"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="236" id="mhI-LR-I5w"/>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="ldQ-aO-8Xw"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" alignment="left" maxValue="24" doubleValue="8" tickMarkPosition="below" numberOfTickMarks="25" allowsTickMarkValuesOnly="YES" sliderType="linear" id="qxp-Lt-D6o"/>
                                                                     <connections>
@@ -311,51 +264,23 @@
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="86" y="312" width="32" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14" id="Fo3-vO-Bk1"/>
-                                                                        <constraint firstAttribute="width" constant="28" id="UMm-n3-mDl"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
+                                                                    <rect key="frame" x="91" y="293" width="34" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1.00x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
                                                                         <font key="font" metaFont="system" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
-                                                                    <rect key="frame" x="226" y="279" width="33" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="29" id="79z-wd-dkG"/>
-                                                                        <constraint firstAttribute="height" constant="14" id="Duh-ya-4aq"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
-                                                                    <rect key="frame" x="17" y="324" width="323" height="17"/>
+                                                                    <rect key="frame" x="18" y="305" width="322" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
-                                                                    <rect key="frame" x="19" y="279" width="33" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="29" id="IYU-cQ-T8m"/>
-                                                                        <constraint firstAttribute="height" constant="14" id="JVv-2s-ysw"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
-                                                                    <rect key="frame" x="267" y="292" width="57" height="22"/>
+                                                                    <rect key="frame" x="285" y="273" width="57" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="57" id="Ood-Jd-gLJ"/>
                                                                     </constraints>
@@ -369,7 +294,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="MuS-g5-hvY">
-                                                                    <rect key="frame" x="19" y="238" width="91" height="18"/>
+                                                                    <rect key="frame" x="19" y="219" width="91" height="18"/>
                                                                     <buttonCell key="cell" type="check" title="Deinterlace" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TXm-bA-7y3">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -379,10 +304,10 @@
                                                                     </connections>
                                                                 </button>
                                                                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IWj-Dg-ZDI">
-                                                                    <rect key="frame" x="0.0" y="211" width="373" height="5"/>
+                                                                    <rect key="frame" x="0.0" y="194" width="373" height="5"/>
                                                                 </box>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
-                                                                    <rect key="frame" x="17" y="172" width="323" height="17"/>
+                                                                    <rect key="frame" x="17" y="155" width="323" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="Xez-sb-mfB">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -390,17 +315,16 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sBU-NZ-sp3">
-                                                                    <rect key="frame" x="93" y="138" width="229" height="15"/>
+                                                                    <rect key="frame" x="100" y="121" width="225" height="15"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="0Sg-Ca-QjC"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="bF8-qZ-hks"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
-                                                                    <rect key="frame" x="18" y="136" width="76" height="17"/>
+                                                                    <rect key="frame" x="18" y="121" width="76" height="14"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="72" id="TvH-N9-GfJ"/>
-                                                                        <constraint firstAttribute="height" constant="17" id="X61-kd-B4a"/>
+                                                                        <constraint firstAttribute="width" constant="72" id="TvH-N9-GfJ"/>
                                                                     </constraints>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="cdR-uY-riN">
                                                                         <font key="font" metaFont="smallSystem"/>
@@ -409,17 +333,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Ww-YT-a8e">
-                                                                    <rect key="frame" x="93" y="110" width="229" height="15"/>
+                                                                    <rect key="frame" x="100" y="96" width="225" height="15"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="d8Q-Fw-bbA"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="Mtl-BL-VYs"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
-                                                                    <rect key="frame" x="18" y="108" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="SUH-N6-OC2"/>
-                                                                    </constraints>
+                                                                    <rect key="frame" x="18" y="96" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="eDl-Si-LSa">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -427,17 +348,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qeO-tk-I0D">
-                                                                    <rect key="frame" x="93" y="82" width="229" height="15"/>
+                                                                    <rect key="frame" x="100" y="71" width="225" height="15"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="aEN-2P-ffr"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="64F-Yg-BY8"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
-                                                                    <rect key="frame" x="18" y="80" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="EAl-du-IHD"/>
-                                                                    </constraints>
+                                                                    <rect key="frame" x="18" y="71" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Rky-lo-Buu">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -445,17 +363,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SL7-DZ-5ff">
-                                                                    <rect key="frame" x="93" y="54" width="229" height="15"/>
+                                                                    <rect key="frame" x="100" y="46" width="225" height="15"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="IEh-at-wdd"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="h5f-VW-qGS"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
-                                                                    <rect key="frame" x="18" y="52" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="uQX-b9-7MG"/>
-                                                                    </constraints>
+                                                                    <rect key="frame" x="18" y="46" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="r6x-z0-oFC">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -463,17 +378,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ntv-89-1iw">
-                                                                    <rect key="frame" x="93" y="26" width="229" height="15"/>
+                                                                    <rect key="frame" x="100" y="21" width="225" height="15"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="MTr-Ze-dRm"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="b6L-ZX-hlF"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
-                                                                    <rect key="frame" x="18" y="24" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="fmX-dE-dgH"/>
-                                                                    </constraints>
+                                                                    <rect key="frame" x="18" y="21" width="76" height="14"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="eLh-fu-pMj">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -481,7 +393,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RVg-iv-SLo">
-                                                                    <rect key="frame" x="333" y="137" width="20" height="17"/>
+                                                                    <rect key="frame" x="333" y="120" width="20" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="20" id="Blq-7B-wXj"/>
                                                                         <constraint firstAttribute="height" constant="17" id="K2i-XQ-bmF"/>
@@ -495,7 +407,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="g2t-lZ-AEy">
-                                                                    <rect key="frame" x="333" y="109" width="20" height="17"/>
+                                                                    <rect key="frame" x="333" y="95" width="20" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="No4-dM-lef"/>
                                                                         <constraint firstAttribute="width" constant="20" id="jcC-Wn-oMq"/>
@@ -509,7 +421,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="N1k-37-4OP">
-                                                                    <rect key="frame" x="333" y="81" width="20" height="17"/>
+                                                                    <rect key="frame" x="333" y="70" width="20" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="BH7-Hv-t8g"/>
                                                                         <constraint firstAttribute="width" constant="20" id="USW-FS-jQa"/>
@@ -523,7 +435,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="Cec-wN-J62">
-                                                                    <rect key="frame" x="333" y="53" width="20" height="17"/>
+                                                                    <rect key="frame" x="333" y="45" width="20" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="hEq-A3-uQc"/>
                                                                         <constraint firstAttribute="width" constant="20" id="xPQ-W8-bBW"/>
@@ -537,7 +449,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <button verticalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="Cs3-ib-x4Y">
-                                                                    <rect key="frame" x="333" y="25" width="20" height="17"/>
+                                                                    <rect key="frame" x="333" y="20" width="20" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="HBL-aN-fWE"/>
                                                                         <constraint firstAttribute="width" constant="20" id="q46-CR-8Im"/>
@@ -550,8 +462,57 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="5MT-kZ-5Mh"/>
                                                                     </connections>
                                                                 </button>
+                                                                <stackView distribution="equalCentering" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="T29-ww-YfA">
+                                                                    <rect key="frame" x="21" y="262" width="254" height="11"/>
+                                                                    <subviews>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
+                                                                            <rect key="frame" x="-2" y="0.0" width="29" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
+                                                                            <rect key="frame" x="81.5" y="0.0" width="18" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
+                                                                            <rect key="frame" x="158.5" y="0.0" width="19" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
+                                                                            <rect key="frame" x="236" y="0.0" width="20" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                    </visibilityPriorities>
+                                                                    <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                    </customSpacing>
+                                                                </stackView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
-                                                                    <rect key="frame" x="327" y="295" width="11" height="17"/>
+                                                                    <rect key="frame" x="344" y="276" width="11" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="x" id="W7H-mU-v3D">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -563,96 +524,93 @@
                                                                 <constraint firstAttribute="trailing" secondItem="Cec-wN-J62" secondAttribute="trailing" constant="20" id="0VS-7a-ogO"/>
                                                                 <constraint firstItem="kUi-hW-BR6" firstAttribute="top" secondItem="oAm-jJ-3kE" secondAttribute="bottom" constant="8" id="0zM-1z-rD8"/>
                                                                 <constraint firstItem="d4r-sL-0Vo" firstAttribute="top" secondItem="bza-SA-tXE" secondAttribute="bottom" constant="22" id="2dd-6U-5JF"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="2el-E9-Qtg"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="2fd-vu-drk"/>
                                                                 <constraint firstItem="g2t-lZ-AEy" firstAttribute="centerY" secondItem="0Ww-YT-a8e" secondAttribute="centerY" id="3Kh-dx-oIx"/>
                                                                 <constraint firstAttribute="trailing" secondItem="N1k-37-4OP" secondAttribute="trailing" constant="20" id="5br-Q9-w6g"/>
                                                                 <constraint firstItem="ykw-rb-M9D" firstAttribute="top" secondItem="Ng5-FC-tts" secondAttribute="bottom" constant="8" id="6Od-LZ-fNN"/>
+                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="trailing" secondItem="KVn-1o-Qzh" secondAttribute="trailing" id="7F0-gY-Hav"/>
                                                                 <constraint firstItem="7vv-En-VYY" firstAttribute="top" secondItem="kUi-hW-BR6" secondAttribute="bottom" constant="22" id="7nW-Fa-zR9"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ntv-89-1iw" secondAttribute="trailing" constant="51" id="8GY-ka-LVa"/>
-                                                                <constraint firstItem="KVn-1o-Qzh" firstAttribute="top" secondItem="dFy-zT-BqP" secondAttribute="bottom" constant="19" id="970-TZ-ALY"/>
+                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="centerY" secondItem="8Uj-eX-hSm" secondAttribute="centerY" id="7yD-bF-tRz"/>
+                                                                <constraint firstItem="KVn-1o-Qzh" firstAttribute="top" secondItem="dFy-zT-BqP" secondAttribute="bottom" constant="20" id="970-TZ-ALY"/>
                                                                 <constraint firstItem="8ZJ-PD-t0R" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="9Sd-Mo-oNR"/>
                                                                 <constraint firstItem="ItN-JT-puN" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kUi-hW-BR6" secondAttribute="trailing" constant="8" id="AE2-Nj-RJv"/>
+                                                                <constraint firstItem="g2t-lZ-AEy" firstAttribute="leading" secondItem="0Ww-YT-a8e" secondAttribute="trailing" constant="8" id="AJV-vQ-peR"/>
+                                                                <constraint firstItem="T29-ww-YfA" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="Al2-3q-mqI"/>
                                                                 <constraint firstItem="MuS-g5-hvY" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="21" id="Azc-qS-MPo"/>
-                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="centerY" secondItem="8Uj-eX-hSm" secondAttribute="centerY" constant="-1" id="B0c-jl-1XQ"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="top" secondItem="2Zt-RU-LEK" secondAttribute="bottom" constant="11" id="B7h-Eh-6Vi"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="C61-e9-1jh"/>
-                                                                <constraint firstItem="IWj-Dg-ZDI" firstAttribute="top" secondItem="MuS-g5-hvY" secondAttribute="bottom" constant="26" id="Cvj-xB-WN6"/>
-                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="leading" secondItem="kYz-ZC-58W" secondAttribute="trailing" constant="1" id="DGv-8S-1cx"/>
+                                                                <constraint firstItem="N1k-37-4OP" firstAttribute="leading" secondItem="qeO-tk-I0D" secondAttribute="trailing" constant="8" id="CF9-lf-hE6"/>
+                                                                <constraint firstItem="IWj-Dg-ZDI" firstAttribute="top" secondItem="MuS-g5-hvY" secondAttribute="bottom" constant="24" id="Cvj-xB-WN6"/>
+                                                                <constraint firstItem="nEK-El-M50" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="leading" id="D00-Ws-RAS"/>
+                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="leading" secondItem="kYz-ZC-58W" secondAttribute="trailing" constant="8" id="DGv-8S-1cx"/>
                                                                 <constraint firstAttribute="trailing" secondItem="8ZJ-PD-t0R" secondAttribute="trailing" constant="35" id="Dlg-Mc-874"/>
+                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="leading" constant="72" id="E1b-GU-FYc"/>
                                                                 <constraint firstAttribute="trailing" secondItem="d4r-sL-0Vo" secondAttribute="trailing" constant="35" id="ELU-P9-Djx"/>
-                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="Emd-QP-HFC"/>
                                                                 <constraint firstItem="KVn-1o-Qzh" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="F1e-4k-MuR"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="top" secondItem="8Uj-eX-hSm" secondAttribute="bottom" constant="11" id="FP3-ig-1Zr"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="FTg-hm-WPJ"/>
+                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="centerY" secondItem="nEK-El-M50" secondAttribute="centerY" id="FRs-U5-8x9"/>
+                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="trailing" secondItem="KVn-1o-Qzh" secondAttribute="trailing" id="FhC-FV-AhG"/>
                                                                 <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="3EN-WD-QNI" secondAttribute="bottom" id="Flg-AY-ygf"/>
                                                                 <constraint firstItem="dFy-zT-BqP" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="G5S-Q8-ZeM"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="Grd-2Q-AeY"/>
-                                                                <constraint firstAttribute="trailing" secondItem="SL7-DZ-5ff" secondAttribute="trailing" constant="51" id="HbQ-Yd-1nd"/>
                                                                 <constraint firstItem="ykw-rb-M9D" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" id="IDV-m3-6MW"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="3EN-WD-QNI" secondAttribute="trailing" constant="-95" id="IFy-Z3-eHC"/>
-                                                                <constraint firstAttribute="trailing" secondItem="qeO-tk-I0D" secondAttribute="trailing" constant="51" id="Ike-sL-VNz"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="In6-zL-WCc"/>
-                                                                <constraint firstAttribute="bottom" secondItem="nEK-El-M50" secondAttribute="bottom" constant="24" id="Ltn-af-ibl"/>
+                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="trailing" secondItem="KVn-1o-Qzh" secondAttribute="trailing" id="J6Z-Ie-PNR"/>
+                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="centerY" secondItem="2Zt-RU-LEK" secondAttribute="centerY" id="Ju6-nc-J2b"/>
                                                                 <constraint firstItem="oAm-jJ-3kE" firstAttribute="top" secondItem="Ljl-w6-gIf" secondAttribute="bottom" constant="22" id="Mee-Cf-2h7"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="Nhb-Co-xbZ" secondAttribute="trailing" constant="-29" id="NGa-67-RQ3"/>
-                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="leading" secondItem="8Uj-eX-hSm" secondAttribute="trailing" constant="1" id="NiE-Dm-ChB"/>
+                                                                <constraint firstAttribute="bottom" secondItem="Cs3-ib-x4Y" secondAttribute="bottom" constant="20" id="Mok-H0-1DM"/>
+                                                                <constraint firstItem="nEK-El-M50" firstAttribute="trailing" secondItem="KVn-1o-Qzh" secondAttribute="trailing" id="NVr-4f-ap0"/>
                                                                 <constraint firstAttribute="trailing" secondItem="RVg-iv-SLo" secondAttribute="trailing" constant="20" id="Nod-gk-WVf"/>
-                                                                <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="Omp-b4-73b"/>
+                                                                <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="Omp-b4-73b"/>
                                                                 <constraint firstItem="XAI-y0-tcy" firstAttribute="baseline" secondItem="Ljl-w6-gIf" secondAttribute="baseline" id="Otj-Oc-O3m"/>
-                                                                <constraint firstItem="C7W-xd-6OE" firstAttribute="leading" secondItem="sIs-a1-rGR" secondAttribute="trailing" constant="5" id="OwJ-38-Pvv"/>
+                                                                <constraint firstItem="C7W-xd-6OE" firstAttribute="leading" secondItem="sIs-a1-rGR" secondAttribute="trailing" constant="4" id="OwJ-38-Pvv"/>
+                                                                <constraint firstItem="Cs3-ib-x4Y" firstAttribute="top" secondItem="Cec-wN-J62" secondAttribute="bottom" constant="8" id="PaI-z8-ofe"/>
                                                                 <constraint firstItem="7vv-En-VYY" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="Pdo-MY-Ipv"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="Q6G-Fz-CGT"/>
+                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="centerY" secondItem="KVn-1o-Qzh" secondAttribute="centerY" id="QG5-jj-olY"/>
                                                                 <constraint firstItem="bza-SA-tXE" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="Qa8-ju-KHP"/>
                                                                 <constraint firstAttribute="trailing" secondItem="dFy-zT-BqP" secondAttribute="trailing" constant="35" id="RF3-m9-10f"/>
                                                                 <constraint firstItem="Ljl-w6-gIf" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="SAo-KZ-4ac"/>
                                                                 <constraint firstItem="Cec-wN-J62" firstAttribute="centerY" secondItem="SL7-DZ-5ff" secondAttribute="centerY" id="SbN-O3-hQF"/>
                                                                 <constraint firstItem="8ZJ-PD-t0R" firstAttribute="top" secondItem="rsV-qL-l7b" secondAttribute="bottom" constant="20" id="SsM-RU-d20"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="T08-gr-bMl"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="-29" id="Tfz-E0-gcH"/>
-                                                                <constraint firstAttribute="trailing" secondItem="7vv-En-VYY" secondAttribute="trailing" constant="35" id="UG0-YC-mdd"/>
+                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="leading" secondItem="8Uj-eX-hSm" secondAttribute="trailing" constant="8" id="TrO-bg-xJB"/>
+                                                                <constraint firstItem="N1k-37-4OP" firstAttribute="top" secondItem="g2t-lZ-AEy" secondAttribute="bottom" constant="8" id="U6w-hL-FZB"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7vv-En-VYY" secondAttribute="trailing" constant="35" id="UG0-YC-mdd"/>
                                                                 <constraint firstItem="bza-SA-tXE" firstAttribute="top" secondItem="7vv-En-VYY" secondAttribute="bottom" constant="8" id="UNm-OF-IiO"/>
                                                                 <constraint firstAttribute="trailing" secondItem="g2t-lZ-AEy" secondAttribute="trailing" constant="20" id="V20-xT-lvO"/>
-                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="centerY" secondItem="kYz-ZC-58W" secondAttribute="centerY" constant="-1" id="V50-WA-XT5"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="WaX-of-cel"/>
                                                                 <constraint firstAttribute="trailing" secondItem="Cs3-ib-x4Y" secondAttribute="trailing" constant="20" id="Ws1-7P-jpF"/>
                                                                 <constraint firstItem="ItN-JT-puN" firstAttribute="baseline" secondItem="kUi-hW-BR6" secondAttribute="baseline" id="XEr-4T-4bB"/>
                                                                 <constraint firstItem="N1k-37-4OP" firstAttribute="centerY" secondItem="qeO-tk-I0D" secondAttribute="centerY" id="XJ5-f1-XrE"/>
-                                                                <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="YXU-bO-7fz"/>
+                                                                <constraint firstItem="T29-ww-YfA" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="Xct-mA-6lI"/>
+                                                                <constraint firstItem="g2t-lZ-AEy" firstAttribute="top" secondItem="RVg-iv-SLo" secondAttribute="bottom" constant="8" id="Xnm-2i-qGI"/>
+                                                                <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="YXU-bO-7fz"/>
                                                                 <constraint firstItem="MuS-g5-hvY" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="40" id="Ze7-u3-xCF"/>
                                                                 <constraint firstAttribute="trailing" secondItem="ItN-JT-puN" secondAttribute="trailing" constant="20" id="axE-h4-tZb"/>
                                                                 <constraint firstItem="sIs-a1-rGR" firstAttribute="baseline" secondItem="C7W-xd-6OE" secondAttribute="baseline" id="axs-9b-6io"/>
                                                                 <constraint firstItem="dFy-zT-BqP" firstAttribute="top" secondItem="IWj-Dg-ZDI" secondAttribute="bottom" constant="24" id="bJi-Qb-mOl"/>
-                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="centerY" secondItem="KVn-1o-Qzh" secondAttribute="centerY" constant="-1" id="ekL-0l-eZn"/>
+                                                                <constraint firstItem="RVg-iv-SLo" firstAttribute="leading" secondItem="sBU-NZ-sp3" secondAttribute="trailing" constant="8" id="cpJ-D8-mhp"/>
+                                                                <constraint firstItem="XAI-y0-tcy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ljl-w6-gIf" secondAttribute="trailing" constant="8" id="dlB-20-jtJ"/>
+                                                                <constraint firstItem="Cec-wN-J62" firstAttribute="top" secondItem="N1k-37-4OP" secondAttribute="bottom" constant="8" id="eno-71-4vd"/>
                                                                 <constraint firstItem="Ljl-w6-gIf" firstAttribute="top" secondItem="8ZJ-PD-t0R" secondAttribute="bottom" constant="8" id="fAO-Kh-lMb"/>
-                                                                <constraint firstAttribute="trailing" secondItem="0Ww-YT-a8e" secondAttribute="trailing" constant="51" id="guT-nx-Wk3"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="top" secondItem="KVn-1o-Qzh" secondAttribute="bottom" constant="11" id="h27-1N-oqq"/>
+                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="leading" id="fkU-Xa-Lp4"/>
+                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="trailing" constant="8" id="giG-ad-trC"/>
+                                                                <constraint firstAttribute="trailing" secondItem="C7W-xd-6OE" secondAttribute="trailing" constant="20" id="kpf-eE-XJ6"/>
                                                                 <constraint firstItem="sIs-a1-rGR" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="10" id="lZi-Gn-0wp"/>
                                                                 <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="d4r-sL-0Vo" secondAttribute="bottom" constant="12" id="lxM-no-JPt"/>
                                                                 <constraint firstItem="kUi-hW-BR6" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="lyh-SJ-qRo"/>
                                                                 <constraint firstItem="Ng5-FC-tts" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="top" constant="20" id="mnE-cz-hms"/>
                                                                 <constraint firstItem="sIs-a1-rGR" firstAttribute="centerY" secondItem="UWh-M9-5Nw" secondAttribute="centerY" id="msa-vu-iWm"/>
-                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="centerY" secondItem="nEK-El-M50" secondAttribute="centerY" constant="-1" id="nlv-SX-hed"/>
                                                                 <constraint firstItem="Cs3-ib-x4Y" firstAttribute="centerY" secondItem="ntv-89-1iw" secondAttribute="centerY" id="oaP-Ea-Hxf"/>
-                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="trailing" constant="1" id="oi8-qd-gl7"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Ng5-FC-tts" secondAttribute="trailing" constant="35" id="opt-ak-vjT"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ng5-FC-tts" secondAttribute="trailing" constant="20" id="opt-ak-vjT"/>
                                                                 <constraint firstItem="RVg-iv-SLo" firstAttribute="centerY" secondItem="sBU-NZ-sp3" secondAttribute="centerY" id="p3g-be-o3f"/>
                                                                 <constraint firstItem="IWj-Dg-ZDI" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" id="qz4-0r-Wmb"/>
                                                                 <constraint firstAttribute="trailing" secondItem="oAm-jJ-3kE" secondAttribute="trailing" constant="35" id="rJP-h4-nmQ"/>
+                                                                <constraint firstItem="Cs3-ib-x4Y" firstAttribute="leading" secondItem="ntv-89-1iw" secondAttribute="trailing" constant="8" id="rbf-nk-njp"/>
+                                                                <constraint firstItem="T29-ww-YfA" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="2" id="rzP-c0-UPk"/>
                                                                 <constraint firstAttribute="trailing" secondItem="XAI-y0-tcy" secondAttribute="trailing" constant="20" id="s3L-tw-1U3"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="se1-Eo-JSd"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="top" secondItem="kYz-ZC-58W" secondAttribute="bottom" constant="11" id="tPs-tE-Vha"/>
+                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="leading" id="tca-oL-X9G"/>
                                                                 <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="21" id="tix-10-NM5"/>
-                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="centerY" secondItem="2Zt-RU-LEK" secondAttribute="centerY" constant="-1" id="uES-Tw-LyK"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="ujz-0j-0bK"/>
-                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="leading" secondItem="nEK-El-M50" secondAttribute="trailing" constant="1" id="vwz-ag-OXf"/>
-                                                                <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="xGc-cc-diR"/>
+                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="leading" secondItem="nEK-El-M50" secondAttribute="trailing" constant="8" id="vwz-ag-OXf"/>
+                                                                <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="xGc-cc-diR"/>
+                                                                <constraint firstItem="Cec-wN-J62" firstAttribute="leading" secondItem="SL7-DZ-5ff" secondAttribute="trailing" constant="8" id="xkk-he-VGM"/>
+                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="leading" id="xo9-PW-e0n"/>
                                                                 <constraint firstAttribute="trailing" secondItem="ykw-rb-M9D" secondAttribute="trailing" id="y2x-tm-gpt"/>
-                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="leading" secondItem="2Zt-RU-LEK" secondAttribute="trailing" constant="1" id="y60-T3-dbz"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="-96" id="ye2-KO-sgF"/>
-                                                                <constraint firstAttribute="trailing" secondItem="sBU-NZ-sp3" secondAttribute="trailing" constant="51" id="yjg-bb-MWl"/>
+                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="leading" secondItem="2Zt-RU-LEK" secondAttribute="trailing" constant="8" id="y60-T3-dbz"/>
                                                                 <constraint firstAttribute="trailing" secondItem="IWj-Dg-ZDI" secondAttribute="trailing" id="zbB-sz-CoS"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="wBg-Dk-cUX" secondAttribute="trailing" constant="-96" id="zd4-0W-06H"/>
+                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="centerY" secondItem="kYz-ZC-58W" secondAttribute="centerY" id="zsq-n8-CHZ"/>
                                                             </constraints>
                                                         </customView>
                                                     </subviews>
@@ -675,7 +633,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
-                                            <rect key="frame" x="357" y="0.0" width="16" height="789"/>
+                                            <rect key="frame" x="357" y="0.0" width="16" height="743"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -684,29 +642,29 @@
                                     <constraint firstItem="SHU-hX-9MT" firstAttribute="leading" secondItem="NRI-ba-KMd" secondAttribute="leading" id="1TC-bU-AZC"/>
                                     <constraint firstItem="SHU-hX-9MT" firstAttribute="top" secondItem="NRI-ba-KMd" secondAttribute="top" id="3a6-1b-6B6"/>
                                     <constraint firstAttribute="bottom" secondItem="SHU-hX-9MT" secondAttribute="bottom" id="PVd-ds-phE"/>
-                                    <constraint firstAttribute="trailing" secondItem="SHU-hX-9MT" secondAttribute="trailing" id="R35-dQ-uur"/>
+                                    <constraint firstAttribute="trailing" secondItem="SHU-hX-9MT" secondAttribute="trailing" constant="-13" id="R35-dQ-uur"/>
                                 </constraints>
                             </view>
                         </tabViewItem>
                         <tabViewItem label="Audio" identifier="2" id="bzk-c2-LH5">
                             <view key="view" id="Dxl-wa-zgc">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="789"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="789"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="789"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="277" width="360" height="512"/>
+                                                    <rect key="frame" x="0.0" y="267" width="360" height="476"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="512"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="476"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
-                                                                    <rect key="frame" x="17" y="475" width="310" height="17"/>
+                                                                    <rect key="frame" x="17" y="439" width="83" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio track:" id="x39-62-7KC">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -714,10 +672,10 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS">
-                                                                    <rect key="frame" x="0.0" y="391" width="360" height="76"/>
+                                                                    <rect key="frame" x="0.0" y="355" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="FLg-2m-Zaq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
@@ -761,7 +719,7 @@
                                                                         <constraint firstAttribute="height" constant="76" id="sBV-Kf-cvi"/>
                                                                     </constraints>
                                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="Pal-8c-4eQ">
-                                                                        <rect key="frame" x="0.0" y="-16" width="0.0" height="16"/>
+                                                                        <rect key="frame" x="0.0" y="60" width="360" height="16"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="uet-8b-szq">
@@ -769,20 +727,10 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
-                                                                    <rect key="frame" x="14" y="318" width="317" height="32"/>
-                                                                    <buttonCell key="cell" type="push" title="Load External Audio Track..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8Ax-5X-osl">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="loadExternalAudioAction:" target="-2" id="Qlt-LO-puw"/>
-                                                                    </connections>
-                                                                </button>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a7T-nr-ELY">
-                                                                    <rect key="frame" x="20" y="240" width="240" height="18"/>
+                                                                    <rect key="frame" x="20" y="237" width="240" height="18"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Rhl-RX-l4v"/>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="wto-qh-xfg"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" allowsTickMarkValuesOnly="YES" sliderType="linear" id="ERU-lE-Yhg"/>
                                                                     <connections>
@@ -790,7 +738,7 @@
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
-                                                                    <rect key="frame" x="17" y="354" width="310" height="17"/>
+                                                                    <rect key="frame" x="18" y="318" width="101" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -798,7 +746,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="doa-7T-eeK">
-                                                                    <rect key="frame" x="18" y="229" width="20" height="11"/>
+                                                                    <rect key="frame" x="18" y="226" width="20" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs">
                                                                         <font key="font" metaFont="miniSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -806,7 +754,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kF3-Ee-Pha">
-                                                                    <rect key="frame" x="247" y="229" width="15" height="11"/>
+                                                                    <rect key="frame" x="247" y="226" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="5s" id="C0t-gm-Tim">
                                                                         <font key="font" metaFont="miniSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -814,7 +762,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
-                                                                    <rect key="frame" x="131" y="229" width="19" height="11"/>
+                                                                    <rect key="frame" x="130.5" y="226" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="wgA-op-JP4">
                                                                         <font key="font" metaFont="miniSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -822,7 +770,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0DM-CY-o8W" userLabel="Delay">
-                                                                    <rect key="frame" x="276" y="239" width="64" height="22"/>
+                                                                    <rect key="frame" x="276" y="236" width="64" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="64" id="Alb-o2-pM2"/>
                                                                     </constraints>
@@ -837,7 +785,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
-                                                                    <rect key="frame" x="17" y="281" width="310" height="17"/>
+                                                                    <rect key="frame" x="17" y="278" width="310" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio delay:" id="AKs-VQ-fKF">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -845,18 +793,18 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gR7-cS-zmu" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="130" y="260" width="20" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="s3F-Tl-Siy">
+                                                                    <rect key="frame" x="134" y="257" width="29" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0.0s" usesSingleLineMode="YES" id="s3F-Tl-Siy">
                                                                         <font key="font" metaFont="system" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
-                                                                    <rect key="frame" x="0.0" y="204" width="360" height="5"/>
+                                                                    <rect key="frame" x="0.0" y="201" width="360" height="5"/>
                                                                 </box>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I">
-                                                                    <rect key="frame" x="17" y="171" width="305" height="17"/>
+                                                                    <rect key="frame" x="18" y="168" width="64" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="iS4-Zr-9Ig">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -864,215 +812,373 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="PLF-x4-bMC">
-                                                                    <rect key="frame" x="0.0" y="24" width="360" height="139"/>
+                                                                    <rect key="frame" x="0.0" y="20" width="360" height="140"/>
                                                                     <subviews>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
-                                                                            <rect key="frame" x="20" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="Twm-2U-8ou"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
-                                                                            <rect key="frame" x="47" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="SCy-Om-bV6"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
-                                                                            <rect key="frame" x="74" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="a7E-4j-6g2"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
-                                                                            <rect key="frame" x="101" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TbE-dB-ORk"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
-                                                                            <rect key="frame" x="128" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="4Ra-VR-yOK"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
-                                                                            <rect key="frame" x="155" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="xV9-OM-MHq"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
-                                                                            <rect key="frame" x="182" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TNb-Es-VsX"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
-                                                                            <rect key="frame" x="209" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="P8O-pY-Nby"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
-                                                                            <rect key="frame" x="234" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="GEq-jW-WUw"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
-                                                                            <rect key="frame" x="259" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="5FD-oT-GpE"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
-                                                                            <rect key="frame" x="301" y="125" width="41" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+12 dB" id="4BZ-H1-GEU">
-                                                                                <font key="font" metaFont="smallSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
-                                                                            <rect key="frame" x="303" y="20" width="39" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-12 dB" id="Lpw-ws-Ezh">
-                                                                                <font key="font" metaFont="smallSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
-                                                                            <rect key="frame" x="304" y="73" width="37" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0 dB" id="lBn-YS-jL7">
-                                                                                <font key="font" metaFont="smallSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
-                                                                            <rect key="frame" x="11" y="0.0" width="37" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
-                                                                            <rect key="frame" x="68" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
-                                                                            <rect key="frame" x="95" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
-                                                                            <rect key="frame" x="122" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
-                                                                            <rect key="frame" x="149" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
-                                                                            <rect key="frame" x="176" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
-                                                                            <rect key="frame" x="203" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
-                                                                            <rect key="frame" x="228" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
-                                                                            <rect key="frame" x="253" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
-                                                                            <rect key="frame" x="41" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
-                                                                                <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
+                                                                        <stackView distribution="equalCentering" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="K2Z-nI-3Oq">
+                                                                            <rect key="frame" x="20" y="0.0" width="263" height="140"/>
+                                                                            <subviews>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-J9-1NW">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="28" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
+                                                                                            <rect key="frame" x="5.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="Twm-2U-8ou"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="32" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="e12-8n-EpU">
+                                                                                    <rect key="frame" x="28.5" y="0.0" width="24" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
+                                                                                            <rect key="frame" x="3.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="SCy-Om-bV6"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="28" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="8Vo-in-EfA">
+                                                                                    <rect key="frame" x="57" y="0.0" width="20" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
+                                                                                            <rect key="frame" x="1.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="a7E-4j-6g2"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="uEN-an-lH8">
+                                                                                    <rect key="frame" x="82.5" y="0.0" width="22" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
+                                                                                            <rect key="frame" x="2.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TbE-dB-ORk"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="dzW-J4-19x">
+                                                                                    <rect key="frame" x="109" y="0.0" width="22" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
+                                                                                            <rect key="frame" x="2.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="4Ra-VR-yOK"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="xeh-so-znx">
+                                                                                    <rect key="frame" x="138.5" y="0.0" width="17" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
+                                                                                            <rect key="frame" x="0.0" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="xV9-OM-MHq"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
+                                                                                            <rect key="frame" x="-0.5" y="0.0" width="18" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="jhn-Sf-d6M">
+                                                                                    <rect key="frame" x="165" y="0.0" width="17" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
+                                                                                            <rect key="frame" x="0.0" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TNb-Es-VsX"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
+                                                                                            <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="bQP-M3-eeN">
+                                                                                    <rect key="frame" x="191.5" y="0.0" width="17" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
+                                                                                            <rect key="frame" x="0.0" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="P8O-pY-Nby"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
+                                                                                            <rect key="frame" x="-1.5" y="0.0" width="20" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="3ui-44-2iZ">
+                                                                                    <rect key="frame" x="218" y="0.0" width="17" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
+                                                                                            <rect key="frame" x="0.0" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="GEq-jW-WUw"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
+                                                                                            <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="32z-9I-Hez">
+                                                                                    <rect key="frame" x="243" y="0.0" width="20" height="140"/>
+                                                                                    <subviews>
+                                                                                        <slider horizontalHuggingPriority="750" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
+                                                                                            <rect key="frame" x="1.5" y="18" width="18" height="122"/>
+                                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="5FD-oT-GpE"/>
+                                                                                            <connections>
+                                                                                                <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
+                                                                                            </connections>
+                                                                                        </slider>
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
+                                                                                            <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
+                                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
+                                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                            </textFieldCell>
+                                                                                        </textField>
+                                                                                    </subviews>
+                                                                                    <visibilityPriorities>
+                                                                                        <integer value="1000"/>
+                                                                                        <integer value="1000"/>
+                                                                                    </visibilityPriorities>
+                                                                                    <customSpacing>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                        <real value="3.4028234663852886e+38"/>
+                                                                                    </customSpacing>
+                                                                                </stackView>
+                                                                            </subviews>
+                                                                            <visibilityPriorities>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                            </visibilityPriorities>
+                                                                            <customSpacing>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                            </customSpacing>
+                                                                        </stackView>
+                                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="trailing" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="FqD-Ht-R76">
+                                                                            <rect key="frame" x="303" y="20" width="37" height="112"/>
+                                                                            <subviews>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
+                                                                                    <rect key="frame" x="-2" y="98" width="41" height="14"/>
+                                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+12 dB" id="4BZ-H1-GEU">
+                                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                    </textFieldCell>
+                                                                                </textField>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
+                                                                                    <rect key="frame" x="10" y="49" width="29" height="14"/>
+                                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0 dB" id="lBn-YS-jL7">
+                                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                    </textFieldCell>
+                                                                                </textField>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="39" height="14"/>
+                                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-12 dB" id="Lpw-ws-Ezh">
+                                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                    </textFieldCell>
+                                                                                </textField>
+                                                                            </subviews>
+                                                                            <visibilityPriorities>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                            </visibilityPriorities>
+                                                                            <customSpacing>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                            </customSpacing>
+                                                                        </stackView>
                                                                     </subviews>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="139" id="eMl-tL-SYh"/>
+                                                                        <constraint firstItem="FqD-Ht-R76" firstAttribute="top" secondItem="PLF-x4-bMC" secondAttribute="top" constant="8" id="69w-9C-cqB"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="FqD-Ht-R76" secondAttribute="trailing" constant="20" id="FAf-eV-5Qi"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="K2Z-nI-3Oq" secondAttribute="bottom" id="Xp7-Bn-4Xh"/>
+                                                                        <constraint firstItem="K2Z-nI-3Oq" firstAttribute="leading" secondItem="PLF-x4-bMC" secondAttribute="leading" constant="20" id="aOJ-At-7Bx"/>
+                                                                        <constraint firstAttribute="height" constant="140" id="eMl-tL-SYh"/>
+                                                                        <constraint firstItem="FqD-Ht-R76" firstAttribute="leading" secondItem="K2Z-nI-3Oq" secondAttribute="trailing" constant="20" id="f38-cZ-eZA"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="FqD-Ht-R76" secondAttribute="bottom" constant="20" id="kXM-hc-nUG"/>
+                                                                        <constraint firstItem="K2Z-nI-3Oq" firstAttribute="top" secondItem="PLF-x4-bMC" secondAttribute="top" id="oRG-ZW-7fd"/>
                                                                     </constraints>
                                                                 </customView>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="dB1-5J-5YU">
-                                                                    <rect key="frame" x="324" y="171" width="16" height="16"/>
+                                                                    <rect key="frame" x="324" y="168" width="16" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="16" id="T2d-bE-Rq1"/>
-                                                                        <constraint firstAttribute="height" constant="16" id="xEH-z6-Ltg"/>
+                                                                        <constraint firstAttribute="width" secondItem="dB1-5J-5YU" secondAttribute="height" multiplier="1:1" id="tR1-1G-Tnz"/>
                                                                     </constraints>
                                                                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" imageScaling="proportionallyUpOrDown" inset="2" id="Cgw-yU-AOF">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1082,46 +1188,56 @@
                                                                         <action selector="resetAudioEqAction:" target="-2" id="2mv-yD-fAu"/>
                                                                     </connections>
                                                                 </button>
+                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
+                                                                    <rect key="frame" x="119" y="308" width="209" height="32"/>
+                                                                    <buttonCell key="cell" type="push" title="Load External Audio Track..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8Ax-5X-osl">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="loadExternalAudioAction:" target="-2" id="Qlt-LO-puw"/>
+                                                                    </connections>
+                                                                </button>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="0QV-7k-pBU"/>
+                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="0QV-7k-pBU"/>
                                                                 <constraint firstItem="kF3-Ee-Pha" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="0XD-ee-xVQ"/>
                                                                 <constraint firstAttribute="trailing" secondItem="PLF-x4-bMC" secondAttribute="trailing" id="1q2-vE-SkR"/>
                                                                 <constraint firstItem="E4v-kh-61H" firstAttribute="top" secondItem="my2-5o-bNb" secondAttribute="top" constant="20" id="1y4-Kv-vat"/>
                                                                 <constraint firstItem="0DM-CY-o8W" firstAttribute="leading" secondItem="a7T-nr-ELY" secondAttribute="trailing" constant="16" id="20o-RN-jw7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="dB1-5J-5YU" secondAttribute="trailing" constant="20" id="2j8-Vy-2QJ"/>
-                                                                <constraint firstAttribute="trailing" secondItem="IHl-Ks-v7I" secondAttribute="trailing" constant="40" id="305-x4-mBU"/>
                                                                 <constraint firstItem="doa-7T-eeK" firstAttribute="leading" secondItem="a7T-nr-ELY" secondAttribute="leading" id="62g-RQ-baB"/>
                                                                 <constraint firstItem="ZPW-fz-5Oi" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="9aM-rf-Ubw"/>
-                                                                <constraint firstAttribute="trailing" secondItem="E4v-kh-61H" secondAttribute="trailing" constant="35" id="9ol-Ih-xQV"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="E4v-kh-61H" secondAttribute="trailing" constant="20" id="9ol-Ih-xQV"/>
                                                                 <constraint firstItem="KKr-0Y-831" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="AXq-h3-TVD"/>
                                                                 <constraint firstItem="0DM-CY-o8W" firstAttribute="centerY" secondItem="a7T-nr-ELY" secondAttribute="centerY" constant="-1" id="B5R-Ja-IjZ"/>
                                                                 <constraint firstItem="a7T-nr-ELY" firstAttribute="top" secondItem="gR7-cS-zmu" secondAttribute="bottom" constant="2" id="C2d-F4-WIg"/>
                                                                 <constraint firstItem="doa-7T-eeK" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="FFk-YH-GZp"/>
                                                                 <constraint firstItem="C39-jO-zwp" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="GZM-yD-gvm"/>
                                                                 <constraint firstAttribute="trailing" secondItem="KKr-0Y-831" secondAttribute="trailing" id="HbW-t2-Z43"/>
-                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="LQR-09-ikh"/>
+                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="LQR-09-ikh"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="leading" secondItem="kvu-fg-olx" secondAttribute="trailing" constant="8" id="Mco-hj-MHE"/>
                                                                 <constraint firstItem="a7T-nr-ELY" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="Mj2-sZ-AFW"/>
-                                                                <constraint firstAttribute="trailing" secondItem="kvu-fg-olx" secondAttribute="trailing" constant="35" id="O0T-4P-XQY"/>
+                                                                <constraint firstAttribute="trailing" secondItem="0DM-CY-o8W" secondAttribute="trailing" constant="20" id="PGx-UC-O1P"/>
                                                                 <constraint firstItem="kF3-Ee-Pha" firstAttribute="trailing" secondItem="a7T-nr-ELY" secondAttribute="trailing" id="PJ2-pg-wRS"/>
                                                                 <constraint firstItem="Qal-0X-4kS" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="bottom" constant="8" id="PfL-cK-sd5"/>
                                                                 <constraint firstItem="C39-jO-zwp" firstAttribute="centerX" secondItem="a7T-nr-ELY" secondAttribute="centerX" id="Pq3-Ff-F3F"/>
                                                                 <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="18" id="Q61-jq-LnT"/>
-                                                                <constraint firstAttribute="trailing" secondItem="XdF-fV-DCz" secondAttribute="trailing" constant="35" id="Qgj-tE-Ji4"/>
+                                                                <constraint firstItem="dB1-5J-5YU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IHl-Ks-v7I" secondAttribute="trailing" constant="8" id="QNN-mu-WjM"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XdF-fV-DCz" secondAttribute="trailing" constant="20" id="Qgj-tE-Ji4"/>
                                                                 <constraint firstItem="Qal-0X-4kS" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="SwW-S7-LX2"/>
-                                                                <constraint firstItem="gR7-cS-zmu" firstAttribute="centerX" secondItem="a7T-nr-ELY" secondAttribute="centerX" id="VmP-Jn-P9Z"/>
                                                                 <constraint firstItem="dB1-5J-5YU" firstAttribute="centerY" secondItem="IHl-Ks-v7I" secondAttribute="centerY" id="Ym6-Rk-xwx"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="aOX-MS-ZZW"/>
                                                                 <constraint firstItem="PLF-x4-bMC" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="dRT-Ri-a9H"/>
                                                                 <constraint firstItem="E4v-kh-61H" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="f6t-BV-Nqr"/>
-                                                                <constraint firstAttribute="bottom" secondItem="PLF-x4-bMC" secondAttribute="bottom" constant="24" id="gbq-VK-CJq"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="8" id="gud-hM-Hf0"/>
+                                                                <constraint firstItem="gR7-cS-zmu" firstAttribute="leading" secondItem="a7T-nr-ELY" secondAttribute="leading" constant="116" id="fRb-Oo-uXF"/>
+                                                                <constraint firstAttribute="bottom" secondItem="PLF-x4-bMC" secondAttribute="bottom" constant="20" id="gbq-VK-CJq"/>
                                                                 <constraint firstItem="a7T-nr-ELY" firstAttribute="top" secondItem="ZPW-fz-5Oi" secondAttribute="bottom" constant="23" id="h2O-at-cpJ"/>
                                                                 <constraint firstItem="KKr-0Y-831" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" constant="33" id="lUv-nd-FbU"/>
                                                                 <constraint firstAttribute="trailing" secondItem="Qal-0X-4kS" secondAttribute="trailing" id="lda-T8-U6J"/>
-                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="27" id="pbW-gp-age"/>
+                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="20" id="pbW-gp-age"/>
                                                                 <constraint firstAttribute="trailing" secondItem="ZPW-fz-5Oi" secondAttribute="trailing" constant="35" id="tRW-zx-YUE"/>
                                                                 <constraint firstItem="kvu-fg-olx" firstAttribute="top" secondItem="Qal-0X-4kS" secondAttribute="bottom" constant="20" id="wOv-GA-HuD"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="baseline" secondItem="kvu-fg-olx" secondAttribute="baseline" id="xfb-DC-Nak"/>
                                                                 <constraint firstItem="PLF-x4-bMC" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="8" id="zPs-Z3-aNL"/>
                                                             </constraints>
                                                         </customView>
@@ -1142,11 +1258,11 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE">
-                                            <rect key="frame" x="0.0" y="773" width="360" height="16"/>
+                                            <rect key="frame" x="0.0" y="727" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="17z-n6-rH9">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="789"/>
+                                            <rect key="frame" x="344" y="0.0" width="16" height="743"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1159,25 +1275,25 @@
                                 </constraints>
                             </view>
                         </tabViewItem>
-                        <tabViewItem label="Subtitle" identifier="" id="jND-MZ-sKB">
+                        <tabViewItem label="Subtitles" identifier="3" id="jND-MZ-sKB">
                             <view key="view" id="MrM-2b-7ob">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="-9" width="360" height="832"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="Sub Basic">
-                                                            <rect key="frame" x="0.0" y="411" width="360" height="421"/>
+                                                            <rect key="frame" x="0.0" y="352" width="360" height="391"/>
                                                             <subviews>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh">
-                                                                    <rect key="frame" x="0.0" y="304" width="360" height="72"/>
+                                                                    <rect key="frame" x="0.0" y="274" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1224,7 +1340,7 @@
                                                                         <constraint firstAttribute="height" constant="72" id="lC0-Wa-BTh"/>
                                                                     </constraints>
                                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="T7q-K8-765">
-                                                                        <rect key="frame" x="0.0" y="-16" width="0.0" height="16"/>
+                                                                        <rect key="frame" x="0.0" y="56" width="352" height="16"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="j0M-29-ecd">
@@ -1233,7 +1349,7 @@
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg">
-                                                                    <rect key="frame" x="0.0" y="187" width="360" height="72"/>
+                                                                    <rect key="frame" x="0.0" y="157" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1280,7 +1396,7 @@
                                                                         <constraint firstAttribute="height" constant="72" id="h9T-Pz-NPG"/>
                                                                     </constraints>
                                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ZW0-tb-txz">
-                                                                        <rect key="frame" x="0.0" y="-16" width="0.0" height="16"/>
+                                                                        <rect key="frame" x="0.0" y="56" width="352" height="16"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                     <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="YIS-JA-mpZ">
@@ -1289,7 +1405,7 @@
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
-                                                                    <rect key="frame" x="17" y="384" width="310" height="17"/>
+                                                                    <rect key="frame" x="18" y="354" width="60" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1297,7 +1413,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Subtitle">
-                                                                    <rect key="frame" x="17" y="267" width="310" height="17"/>
+                                                                    <rect key="frame" x="18" y="237" width="131" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1305,59 +1421,72 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="Sub Delay">
-                                                                    <rect key="frame" x="17" y="150" width="310" height="17"/>
+                                                                    <rect key="frame" x="17" y="120" width="123" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External subtitles:" id="RA1-fF-OrB">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SpJ-zD-xUM">
-                                                                    <rect key="frame" x="14" y="114" width="317" height="32"/>
-                                                                    <buttonCell key="cell" type="push" title="Load Subtitle..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="C97-zJ-O3Y">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="loadExternalSubAction:" target="-2" id="vgy-jn-lTU"/>
-                                                                    </connections>
-                                                                </button>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5">
-                                                                    <rect key="frame" x="20" y="37" width="240" height="18"/>
+                                                                    <rect key="frame" x="20" y="40" width="248" height="18"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="Qpm-gC-Y2e"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" allowsTickMarkValuesOnly="YES" sliderType="linear" id="h1D-gP-Dst"/>
                                                                     <connections>
                                                                         <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
-                                                                    <rect key="frame" x="18" y="26" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="241" y="26" width="21" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
+                                                                <stackView distribution="equalCentering" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="feR-n9-dpN">
+                                                                    <rect key="frame" x="20" y="27" width="248" height="11"/>
+                                                                    <subviews>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
+                                                                            <rect key="frame" x="-2" y="0.0" width="20" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
+                                                                            <rect key="frame" x="114.5" y="0.0" width="19" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
+                                                                            <rect key="frame" x="229" y="0.0" width="21" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
+                                                                                <font key="font" metaFont="miniSystem"/>
+                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                    </visibilityPriorities>
+                                                                    <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                    </customSpacing>
+                                                                </stackView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="130" y="55" width="20" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
+                                                                    <rect key="frame" x="138" y="58" width="29" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0.0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
                                                                         <font key="font" metaFont="system" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
-                                                                    <rect key="frame" x="17" y="77" width="310" height="17"/>
+                                                                    <rect key="frame" x="18" y="80" width="98" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1365,7 +1494,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="Delay">
-                                                                    <rect key="frame" x="276" y="36" width="64" height="22"/>
+                                                                    <rect key="frame" x="276" y="39" width="64" height="22"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="64" id="ptd-kK-aWm"/>
                                                                     </constraints>
@@ -1379,63 +1508,62 @@
                                                                         <action selector="customSubDelayEditFinishedAction:" target="-2" id="oMk-9O-MYn"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="131" y="26" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
-                                                                        <font key="font" metaFont="miniSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
+                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SpJ-zD-xUM">
+                                                                    <rect key="frame" x="140" y="110" width="138" height="32"/>
+                                                                    <buttonCell key="cell" type="push" title="Load Subtitles..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="C97-zJ-O3Y">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="loadExternalSubAction:" target="-2" id="vgy-jn-lTU"/>
+                                                                    </connections>
+                                                                </button>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="33J-Xb-Xbh"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="55g-oO-gXc"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="SpJ-zD-xUM" secondAttribute="bottom" constant="27" id="5dh-Cb-Z5Q"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="9mp-6s-MHB"/>
+                                                                <constraint firstAttribute="trailing" secondItem="eOz-bB-vzM" secondAttribute="trailing" constant="20" id="1wg-zP-XSs"/>
+                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="55g-oO-gXc"/>
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="22" id="Axq-IW-PvK"/>
-                                                                <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="C4V-Gw-CZp"/>
-                                                                <constraint firstAttribute="trailing" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="35" id="CWa-3H-hWP"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="Cev-r5-9om"/>
-                                                                <constraint firstAttribute="bottom" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="37" id="Doh-No-t5F"/>
+                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="baseline" secondItem="M2U-rq-X2L" secondAttribute="baseline" id="B12-HB-9kN"/>
+                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="SpJ-zD-xUM" secondAttribute="bottom" constant="20" id="BDg-f0-TgZ"/>
+                                                                <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="C4V-Gw-CZp"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="20" id="CWa-3H-hWP"/>
+                                                                <constraint firstAttribute="bottom" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="40" id="Doh-No-t5F"/>
+                                                                <constraint firstItem="feR-n9-dpN" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Dw8-uh-I71"/>
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" id="Fdp-D4-VPU"/>
-                                                                <constraint firstAttribute="trailing" secondItem="SpJ-zD-xUM" secondAttribute="trailing" constant="35" id="HwV-jO-qIQ"/>
+                                                                <constraint firstItem="feR-n9-dpN" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="2" id="GGQ-nC-HEr"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SpJ-zD-xUM" secondAttribute="trailing" constant="20" id="HwV-jO-qIQ"/>
                                                                 <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
                                                                 <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
-                                                                <constraint firstAttribute="trailing" secondItem="M2U-rq-X2L" secondAttribute="trailing" constant="35" id="LH3-mi-eMt"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="16" id="LTf-pu-8fz"/>
-                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="McI-dO-bRE"/>
+                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
-                                                                <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="O5J-FT-DtN"/>
-                                                                <constraint firstItem="VbE-TV-lb5" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Q0F-ty-AhB"/>
-                                                                <constraint firstAttribute="trailing" secondItem="cOv-Yl-KdH" secondAttribute="trailing" constant="35" id="SRy-t5-N0K"/>
-                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="Xho-X4-uiS"/>
+                                                                <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="O5J-FT-DtN"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cOv-Yl-KdH" secondAttribute="trailing" constant="20" id="SRy-t5-N0K"/>
+                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="leading" secondItem="M2U-rq-X2L" secondAttribute="trailing" constant="8" id="Uba-r0-f5X"/>
                                                                 <constraint firstItem="M2U-rq-X2L" firstAttribute="top" secondItem="LMp-7Y-Rxg" secondAttribute="bottom" constant="20" id="Y58-bK-q43"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="8" id="hl3-X4-nod"/>
-                                                                <constraint firstItem="SpJ-zD-xUM" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="icN-eS-mnn"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="kSN-80-IMR"/>
-                                                                <constraint firstAttribute="trailing" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="35" id="kUD-ee-efc"/>
-                                                                <constraint firstItem="VbE-TV-lb5" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="nBf-Bg-Rdb"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="20" id="kUD-ee-efc"/>
                                                                 <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" constant="-1" id="rgl-9k-oY7"/>
+                                                                <constraint firstItem="feR-n9-dpN" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="smZ-g2-MIV"/>
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="t39-NF-kSH"/>
+                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" constant="120" id="tSt-6x-AfJ"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="8" id="uj7-Lc-oLk"/>
                                                                 <constraint firstItem="M2U-rq-X2L" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="vM3-dy-eKG"/>
                                                             </constraints>
                                                         </customView>
                                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jRc-VZ-Vv2">
-                                                            <rect key="frame" x="0.0" y="409" width="360" height="5"/>
+                                                            <rect key="frame" x="0.0" y="350" width="360" height="5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="W2h-DQ-cHB"/>
                                                             </constraints>
                                                         </box>
                                                         <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSw-NK-ZU6" userLabel="Sub Style">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="411"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="352"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
-                                                                    <rect key="frame" x="17" y="329" width="305" height="17"/>
+                                                                    <rect key="frame" x="18" y="267" width="44" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scale:" id="Wbx-Ti-qiS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1443,14 +1571,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B8f-KH-BaO">
-                                                                    <rect key="frame" x="18" y="304" width="324" height="19"/>
+                                                                    <rect key="frame" x="66" y="266" width="252" height="19"/>
                                                                     <sliderCell key="cell" continuous="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="above" sliderType="linear" id="Qpw-NH-Unh"/>
                                                                     <connections>
                                                                         <action selector="subScaleSliderAction:" target="-2" id="zEB-hd-cz8"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
-                                                                    <rect key="frame" x="17" y="215" width="310" height="17"/>
+                                                                    <rect key="frame" x="17" y="206" width="73" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Style:" id="ZBd-13-lA1">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1458,7 +1586,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR">
-                                                                    <rect key="frame" x="18" y="363" width="324" height="28"/>
+                                                                    <rect key="frame" x="18" y="304" width="324" height="28"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="320" id="TJx-rX-qcD"/>
                                                                     </constraints>
@@ -1469,12 +1597,12 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="XwE-7y-DXJ" customClass="SettingsListCellView" customModule="IINA" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="24" width="360" height="183"/>
+                                                                    <rect key="frame" x="0.0" y="24" width="360" height="174"/>
                                                                     <subviews>
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="9mo-uL-hfC" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                            <rect key="frame" x="60" y="120" width="23" height="23"/>
+                                                                            <rect key="frame" x="60" y="112" width="23" height="23"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="height" constant="23" id="Rgf-Cu-gr0"/>
+                                                                                <constraint firstAttribute="width" secondItem="9mo-uL-hfC" secondAttribute="height" multiplier="1:1" id="GcT-ma-Lq5"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="tlC-zK-dZi"/>
                                                                             </constraints>
                                                                             <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -1483,9 +1611,9 @@
                                                                             </connections>
                                                                         </colorWell>
                                                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xtF-tn-m9W" userLabel="Text fint size">
-                                                                            <rect key="frame" x="142" y="119" width="77" height="22"/>
+                                                                            <rect key="frame" x="145" y="111" width="70" height="22"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="width" constant="71" id="d7u-5q-vDg"/>
+                                                                                <constraint firstAttribute="width" constant="64" id="d7u-5q-vDg"/>
                                                                             </constraints>
                                                                             <popUpButtonCell key="cell" type="push" title="55" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="mep-aa-rk7" id="qha-uU-Cos" userLabel="Cell">
                                                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1509,7 +1637,7 @@
                                                                             </connections>
                                                                         </popUpButton>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
-                                                                            <rect key="frame" x="18" y="124" width="36" height="14"/>
+                                                                            <rect key="frame" x="18" y="116" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="6LO-6y-IsA">
                                                                                 <font key="font" metaFont="smallSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1517,7 +1645,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
-                                                                            <rect key="frame" x="109" y="124" width="30" height="14"/>
+                                                                            <rect key="frame" x="112" y="116" width="30" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Size:" id="s9l-Hb-SCk">
                                                                                 <font key="font" metaFont="smallSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1525,7 +1653,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
-                                                                            <rect key="frame" x="18" y="97" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="92" width="324" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BORDER" id="GlZ-YU-dNm">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1533,7 +1661,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
-                                                                            <rect key="frame" x="18" y="72" width="36" height="14"/>
+                                                                            <rect key="frame" x="18" y="68" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="ANn-CR-JOV">
                                                                                 <font key="font" metaFont="smallSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1549,7 +1677,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
-                                                                            <rect key="frame" x="100" y="72" width="39" height="14"/>
+                                                                            <rect key="frame" x="103" y="68" width="39" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Width:" id="22j-ra-GAY">
                                                                                 <font key="font" metaFont="smallSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1557,9 +1685,9 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="U2e-zB-Kue" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                            <rect key="frame" x="60" y="68" width="23" height="23"/>
+                                                                            <rect key="frame" x="60" y="64" width="23" height="23"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="height" constant="23" id="OaA-1O-DoB"/>
+                                                                                <constraint firstAttribute="width" secondItem="U2e-zB-Kue" secondAttribute="height" multiplier="1:1" id="FH0-mN-fRI"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="kwW-fi-4RZ"/>
                                                                             </constraints>
                                                                             <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -1570,7 +1698,7 @@
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="Ure-tT-JEy" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
                                                                             <rect key="frame" x="60" y="16" width="23" height="23"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="height" constant="23" id="Ivi-Q0-PSs"/>
+                                                                                <constraint firstAttribute="width" secondItem="Ure-tT-JEy" secondAttribute="height" multiplier="1:1" id="Jy1-3Y-rDf"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="qQW-fy-gq5"/>
                                                                             </constraints>
                                                                             <color key="color" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
@@ -1579,7 +1707,7 @@
                                                                             </connections>
                                                                         </colorWell>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
-                                                                            <rect key="frame" x="18" y="45" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="44" width="86" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BACKGROUND" id="uqb-mz-A22">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1587,7 +1715,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
-                                                                            <rect key="frame" x="18" y="149" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="140" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FONT" id="g6B-DC-lJ0">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1595,9 +1723,9 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bkX-rt-2bg" userLabel="Text Border Width">
-                                                                            <rect key="frame" x="142" y="67" width="77" height="22"/>
+                                                                            <rect key="frame" x="145" y="63" width="70" height="22"/>
                                                                             <constraints>
-                                                                                <constraint firstAttribute="width" constant="71" id="Udn-GZ-bGb"/>
+                                                                                <constraint firstAttribute="width" constant="64" id="Udn-GZ-bGb"/>
                                                                             </constraints>
                                                                             <popUpButtonCell key="cell" type="push" title="3" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="h6k-DT-fv5" id="xGc-Oh-HJO">
                                                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1622,7 +1750,7 @@
                                                                             </connections>
                                                                         </popUpButton>
                                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qGz-rB-dsV">
-                                                                            <rect key="frame" x="251" y="116" width="74" height="28"/>
+                                                                            <rect key="frame" x="251" y="108" width="74" height="28"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="0zp-I9-Wwd"/>
                                                                             </constraints>
@@ -1637,46 +1765,46 @@
                                                                     </subviews>
                                                                     <constraints>
                                                                         <constraint firstItem="Ure-tT-JEy" firstAttribute="centerY" secondItem="kaq-YT-MxI" secondAttribute="centerY" id="0N5-vm-x9t"/>
-                                                                        <constraint firstItem="qGz-rB-dsV" firstAttribute="baseline" secondItem="jj7-9J-PmG" secondAttribute="baseline" id="33c-14-ue3"/>
                                                                         <constraint firstItem="9mo-uL-hfC" firstAttribute="leading" secondItem="jj7-9J-PmG" secondAttribute="trailing" constant="8" id="4R4-CJ-HNX"/>
+                                                                        <constraint firstItem="xtF-tn-m9W" firstAttribute="centerY" secondItem="9mo-uL-hfC" secondAttribute="centerY" id="6lb-Re-F3d"/>
                                                                         <constraint firstItem="xtF-tn-m9W" firstAttribute="centerX" secondItem="XwE-7y-DXJ" secondAttribute="centerX" id="9SK-Ca-gfN"/>
+                                                                        <constraint firstItem="qGz-rB-dsV" firstAttribute="centerY" secondItem="xtF-tn-m9W" secondAttribute="centerY" id="9x4-od-hQG"/>
                                                                         <constraint firstItem="U2e-zB-Kue" firstAttribute="centerY" secondItem="BcK-R6-e8c" secondAttribute="centerY" id="AU8-6b-Sei"/>
                                                                         <constraint firstItem="kaq-YT-MxI" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="Cm8-rC-nJU"/>
-                                                                        <constraint firstAttribute="trailing" secondItem="jTT-rB-qLu" secondAttribute="trailing" constant="20" id="Cqc-Gb-Hn7"/>
-                                                                        <constraint firstItem="bkX-rt-2bg" firstAttribute="baseline" secondItem="7Lw-84-lts" secondAttribute="baseline" id="DIl-FT-DyT"/>
+                                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jTT-rB-qLu" secondAttribute="trailing" constant="20" id="Cqc-Gb-Hn7"/>
                                                                         <constraint firstAttribute="trailing" secondItem="qGz-rB-dsV" secondAttribute="trailing" constant="40" id="GuX-Wj-2jB"/>
-                                                                        <constraint firstItem="WJ6-Fb-q7a" firstAttribute="top" secondItem="BcK-R6-e8c" secondAttribute="bottom" constant="13" id="Lwt-sS-fwH"/>
+                                                                        <constraint firstItem="WJ6-Fb-q7a" firstAttribute="top" secondItem="BcK-R6-e8c" secondAttribute="bottom" constant="10" id="Lwt-sS-fwH"/>
                                                                         <constraint firstItem="bkX-rt-2bg" firstAttribute="centerX" secondItem="XwE-7y-DXJ" secondAttribute="centerX" id="PIR-lu-2WE"/>
                                                                         <constraint firstItem="vLY-cB-GEf" firstAttribute="baseline" secondItem="jj7-9J-PmG" secondAttribute="baseline" id="PjW-fj-Uwz"/>
+                                                                        <constraint firstItem="bkX-rt-2bg" firstAttribute="centerY" secondItem="U2e-zB-Kue" secondAttribute="centerY" id="U99-Ry-c6v"/>
                                                                         <constraint firstItem="bkX-rt-2bg" firstAttribute="leading" secondItem="7Lw-84-lts" secondAttribute="trailing" constant="8" id="WMn-cE-dPv"/>
                                                                         <constraint firstAttribute="trailing" secondItem="xdm-hT-rQs" secondAttribute="trailing" constant="20" id="XAQ-zm-z3h"/>
                                                                         <constraint firstItem="jj7-9J-PmG" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="XYt-Vf-50K"/>
                                                                         <constraint firstItem="9mo-uL-hfC" firstAttribute="centerY" secondItem="jj7-9J-PmG" secondAttribute="centerY" id="YW2-hi-tRk"/>
-                                                                        <constraint firstAttribute="trailing" secondItem="WJ6-Fb-q7a" secondAttribute="trailing" constant="20" id="bHB-uf-Gw7"/>
+                                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WJ6-Fb-q7a" secondAttribute="trailing" constant="20" id="bHB-uf-Gw7"/>
                                                                         <constraint firstItem="xtF-tn-m9W" firstAttribute="leading" secondItem="vLY-cB-GEf" secondAttribute="trailing" constant="8" id="cCg-0c-LMp"/>
-                                                                        <constraint firstItem="xdm-hT-rQs" firstAttribute="top" secondItem="jj7-9J-PmG" secondAttribute="bottom" constant="13" id="fL1-WH-4Dv"/>
-                                                                        <constraint firstItem="BcK-R6-e8c" firstAttribute="top" secondItem="xdm-hT-rQs" secondAttribute="bottom" constant="11" id="g3O-hP-Eh8"/>
+                                                                        <constraint firstItem="xdm-hT-rQs" firstAttribute="top" secondItem="jj7-9J-PmG" secondAttribute="bottom" constant="10" id="fL1-WH-4Dv"/>
+                                                                        <constraint firstItem="BcK-R6-e8c" firstAttribute="top" secondItem="xdm-hT-rQs" secondAttribute="bottom" constant="10" id="g3O-hP-Eh8"/>
                                                                         <constraint firstItem="WJ6-Fb-q7a" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="hU0-aj-Q93"/>
-                                                                        <constraint firstItem="jj7-9J-PmG" firstAttribute="top" secondItem="jTT-rB-qLu" secondAttribute="bottom" constant="11" id="j3Z-Tc-teg"/>
+                                                                        <constraint firstItem="jj7-9J-PmG" firstAttribute="top" secondItem="jTT-rB-qLu" secondAttribute="bottom" constant="10" id="j3Z-Tc-teg"/>
                                                                         <constraint firstItem="jTT-rB-qLu" firstAttribute="top" secondItem="XwE-7y-DXJ" secondAttribute="top" constant="20" id="kIM-1C-00c"/>
                                                                         <constraint firstItem="7Lw-84-lts" firstAttribute="baseline" secondItem="BcK-R6-e8c" secondAttribute="baseline" id="kSf-Xa-B8J"/>
                                                                         <constraint firstAttribute="bottom" secondItem="kaq-YT-MxI" secondAttribute="bottom" constant="20" id="pzz-xW-JOD"/>
                                                                         <constraint firstItem="Ure-tT-JEy" firstAttribute="leading" secondItem="kaq-YT-MxI" secondAttribute="trailing" constant="8" id="qnE-hM-7aL"/>
                                                                         <constraint firstItem="jTT-rB-qLu" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="qs9-eC-h1L"/>
-                                                                        <constraint firstItem="xtF-tn-m9W" firstAttribute="baseline" secondItem="vLY-cB-GEf" secondAttribute="baseline" id="tJv-0k-NF2"/>
                                                                         <constraint firstItem="U2e-zB-Kue" firstAttribute="leading" secondItem="BcK-R6-e8c" secondAttribute="trailing" constant="8" id="tkf-e9-6dm"/>
                                                                         <constraint firstItem="xdm-hT-rQs" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="xEB-cv-Osv"/>
-                                                                        <constraint firstItem="kaq-YT-MxI" firstAttribute="top" secondItem="WJ6-Fb-q7a" secondAttribute="bottom" constant="11" id="xtS-AV-MhM"/>
+                                                                        <constraint firstItem="kaq-YT-MxI" firstAttribute="top" secondItem="WJ6-Fb-q7a" secondAttribute="bottom" constant="10" id="xtS-AV-MhM"/>
                                                                         <constraint firstItem="BcK-R6-e8c" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="zy9-7s-8pJ"/>
                                                                     </constraints>
                                                                 </customView>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
-                                                                    <rect key="frame" x="324" y="329" width="16" height="16"/>
+                                                                    <rect key="frame" x="324" y="267" width="16" height="16"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="16" id="GIz-PJ-9SR"/>
-                                                                        <constraint firstAttribute="width" constant="16" id="HE1-PU-O12"/>
+                                                                        <constraint firstAttribute="width" secondItem="8ZC-Wx-nt7" secondAttribute="height" multiplier="1:1" id="6H8-an-kzq"/>
+                                                                        <constraint firstAttribute="width" constant="16" id="RJ8-MW-Hsw"/>
                                                                     </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" imageScaling="proportionallyUpOrDown" inset="2" id="ojj-5V-n3t">
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" controlSize="small" imageScaling="proportionallyUpOrDown" inset="2" id="ojj-5V-n3t">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                     </buttonCell>
@@ -1685,7 +1813,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
-                                                                    <rect key="frame" x="17" y="272" width="305" height="17"/>
+                                                                    <rect key="frame" x="18" y="243" width="61" height="17"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Position:" id="t03-36-Zge">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1693,8 +1821,8 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lzW-d6-Asr">
-                                                                    <rect key="frame" x="18" y="247" width="324" height="19"/>
-                                                                    <sliderCell key="cell" continuous="YES" alignment="left" maxValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
+                                                                    <rect key="frame" x="83" y="242" width="259" height="19"/>
+                                                                    <sliderCell key="cell" continuous="YES" alignment="left" maxValue="100" doubleValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
                                                                     <connections>
                                                                         <action selector="subPosSliderAction:" target="-2" id="Top-XW-i2A"/>
                                                                     </connections>
@@ -1703,27 +1831,26 @@
                                                             <constraints>
                                                                 <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="6Qf-qa-Ysv"/>
                                                                 <constraint firstItem="XwE-7y-DXJ" firstAttribute="top" secondItem="ipr-WR-eax" secondAttribute="bottom" constant="8" id="6Vb-CZ-GSt"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="top" secondItem="8ZC-Wx-nt7" secondAttribute="bottom" constant="8" id="75S-2r-O03"/>
-                                                                <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" id="9c1-cn-GKO"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="G3N-KD-dhF"/>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="17" id="GBD-Yz-zZx"/>
-                                                                <constraint firstAttribute="trailing" secondItem="OEX-Gn-xCa" secondAttribute="trailing" constant="40" id="Gf4-uU-mKg"/>
-                                                                <constraint firstAttribute="trailing" secondItem="B8f-KH-BaO" secondAttribute="trailing" constant="20" id="Gha-iE-oGu"/>
+                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="OEX-Gn-xCa" secondAttribute="trailing" constant="8" id="Dgm-Mh-AUv"/>
+                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="centerY" secondItem="OEX-Gn-xCa" secondAttribute="centerY" id="FE1-hy-EJm"/>
+                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="centerY" secondItem="B8f-KH-BaO" secondAttribute="centerY" id="Gtd-Mh-QTJ"/>
+                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="leading" secondItem="B8f-KH-BaO" secondAttribute="trailing" constant="8" id="Ifo-NK-ckJ"/>
                                                                 <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="Ilc-HK-W4o"/>
                                                                 <constraint firstAttribute="trailing" secondItem="XwE-7y-DXJ" secondAttribute="trailing" id="J4W-zE-0MD"/>
-                                                                <constraint firstAttribute="trailing" secondItem="lzW-d6-Asr" secondAttribute="trailing" constant="20" id="M0t-y3-cDb"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="PFe-21-jCz"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="aHP-HN-SEj"/>
+                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="Muz-yO-mxR"/>
+                                                                <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" id="ND0-4i-wgI"/>
+                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="20" id="VGa-k1-zby"/>
+                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="aHP-HN-SEj"/>
                                                                 <constraint firstItem="Lkf-Yn-nsR" firstAttribute="top" secondItem="gSw-NK-ZU6" secondAttribute="top" constant="20" id="atW-bb-cRk"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="17" id="bXP-av-Tgw"/>
+                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="20" id="bXP-av-Tgw"/>
                                                                 <constraint firstItem="XwE-7y-DXJ" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" id="d2Y-xa-MBE"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="gHR-MZ-XrC"/>
+                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="8" id="fOu-zY-3I4"/>
+                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="8" id="ifV-0X-iXU"/>
                                                                 <constraint firstAttribute="bottom" secondItem="XwE-7y-DXJ" secondAttribute="bottom" constant="24" id="jg3-w0-k4p"/>
-                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="centerY" secondItem="9xm-5m-Q7G" secondAttribute="centerY" id="mON-va-vGN"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="17" id="rNb-Fl-dTS"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="8" id="vn4-wP-Oee"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="35" id="vrO-Og-xsG"/>
-                                                                <constraint firstAttribute="trailing" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="40" id="xB9-cG-jXW"/>
+                                                                <constraint firstAttribute="trailing" secondItem="lzW-d6-Asr" secondAttribute="trailing" constant="20" id="kIM-Hc-R7X"/>
+                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="centerY" secondItem="9xm-5m-Q7G" secondAttribute="centerY" id="m8i-yQ-trv"/>
+                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="20" id="vrO-Og-xsG"/>
+                                                                <constraint firstAttribute="trailing" secondItem="Lkf-Yn-nsR" secondAttribute="trailing" constant="20" id="xXr-Uq-KGI"/>
                                                             </constraints>
                                                         </customView>
                                                     </subviews>
@@ -1749,11 +1876,11 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="jEt-nA-sGO">
-                                            <rect key="frame" x="0.0" y="807" width="360" height="16"/>
+                                            <rect key="frame" x="0.0" y="727" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="3ZS-ug-kkq">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="823"/>
+                                        <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3ZS-ug-kkq">
+                                            <rect key="frame" x="344" y="0.0" width="16" height="743"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1768,15 +1895,59 @@
                         </tabViewItem>
                     </tabViewItems>
                 </tabView>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw">
+                    <rect key="frame" x="0.0" y="743" width="120.5" height="48"/>
+                    <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
+                        <font key="font" metaFont="systemBold"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="tabBtnAction:" target="-2" id="T17-c3-4hp"/>
+                    </connections>
+                </button>
+                <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK">
+                    <rect key="frame" x="120" y="743" width="120.5" height="48"/>
+                    <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="tabBtnAction:" target="-2" id="mLi-M9-gbN"/>
+                    </connections>
+                </button>
+                <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc">
+                    <rect key="frame" x="240" y="743" width="120" height="48"/>
+                    <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="tabBtnAction:" target="-2" id="IEz-WA-p4g"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="Ma8-6g-tVw" secondAttribute="bottom" id="0OR-BJ-3ZJ"/>
+                <constraint firstItem="3Fk-ey-FhK" firstAttribute="leading" secondItem="Ma8-6g-tVw" secondAttribute="trailing" id="0ku-IR-Eus"/>
+                <constraint firstItem="3Fk-ey-FhK" firstAttribute="width" secondItem="Ma8-6g-tVw" secondAttribute="width" id="1ef-yE-SWA"/>
+                <constraint firstItem="3Fk-ey-FhK" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="86G-SF-ekk"/>
                 <constraint firstAttribute="trailing" secondItem="udA-m2-eJb" secondAttribute="trailing" id="De7-9o-KKe"/>
-                <constraint firstAttribute="width" constant="360" id="L4m-6z-09b"/>
+                <constraint firstItem="3Fk-ey-FhK" firstAttribute="top" secondItem="Ma8-6g-tVw" secondAttribute="top" id="DuB-Gv-3Gy"/>
+                <constraint firstItem="L78-cf-BxB" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="QAh-hX-uhe"/>
                 <constraint firstAttribute="bottom" secondItem="udA-m2-eJb" secondAttribute="bottom" id="SOP-Fn-kKf"/>
+                <constraint firstItem="L78-cf-BxB" firstAttribute="top" secondItem="rH3-pU-mFc" secondAttribute="bottom" id="ShZ-VD-Po3"/>
                 <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="48" id="SrL-is-N20"/>
+                <constraint firstItem="rH3-pU-mFc" firstAttribute="width" secondItem="3Fk-ey-FhK" secondAttribute="width" id="XC1-NF-wCN"/>
+                <constraint firstItem="rH3-pU-mFc" firstAttribute="top" secondItem="3Fk-ey-FhK" secondAttribute="top" id="esZ-vh-Knh"/>
+                <constraint firstItem="Ma8-6g-tVw" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="hvw-BY-iLl"/>
+                <constraint firstAttribute="trailing" secondItem="rH3-pU-mFc" secondAttribute="trailing" id="nvN-e5-UFs"/>
                 <constraint firstItem="udA-m2-eJb" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="tyn-5q-xAw"/>
+                <constraint firstAttribute="trailing" secondItem="L78-cf-BxB" secondAttribute="trailing" id="vKl-UB-Qo4"/>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="rH3-pU-mFc" secondAttribute="bottom" id="wD5-er-MHM"/>
+                <constraint firstItem="rH3-pU-mFc" firstAttribute="leading" secondItem="3Fk-ey-FhK" secondAttribute="trailing" id="zbP-4C-atO"/>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="3Fk-ey-FhK" secondAttribute="bottom" id="zzU-O5-6j9"/>
             </constraints>
-            <point key="canvasLocation" x="102" y="465.5"/>
+            <point key="canvasLocation" x="2782.5" y="149.5"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12106.1" systemVersion="16E163f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12106.1"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
-        <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QuickSettingViewController" customModule="IINA" customModuleProvider="target">
@@ -464,10 +462,10 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="5MT-kZ-5Mh"/>
                                                                     </connections>
                                                                 </button>
-                                                                <stackView distribution="equalCentering" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="T29-ww-YfA">
+                                                                <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="T29-ww-YfA">
                                                                     <rect key="frame" x="21" y="262" width="254" height="11"/>
-                                                                    <subviews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
+                                                                    <beginningViews>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
                                                                             <rect key="frame" x="-2" y="0.0" width="29" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -475,23 +473,32 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
-                                                                            <rect key="frame" x="81.5" y="0.0" width="18" height="11"/>
+                                                                        <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uaf-dz-Gf9">
+                                                                            <rect key="frame" x="25" y="0.0" width="184" height="11"/>
+                                                                        </customView>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
+                                                                            <rect key="frame" x="207" y="0.0" width="18" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
                                                                                 <font key="font" metaFont="miniSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
-                                                                            <rect key="frame" x="158.5" y="0.0" width="19" height="11"/>
+                                                                        <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bae-lI-CIE">
+                                                                            <rect key="frame" x="223" y="0.0" width="0.0" height="11"/>
+                                                                        </customView>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
+                                                                            <rect key="frame" x="221" y="0.0" width="19" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
                                                                                 <font key="font" metaFont="miniSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
+                                                                        <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VSq-CL-JCl">
+                                                                            <rect key="frame" x="238" y="0.0" width="0.0" height="11"/>
+                                                                        </customView>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
                                                                             <rect key="frame" x="236" y="0.0" width="20" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -499,14 +506,24 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                    </subviews>
+                                                                    </beginningViews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="VSq-CL-JCl" firstAttribute="width" secondItem="Bae-lI-CIE" secondAttribute="width" id="SeE-S2-H02"/>
+                                                                        <constraint firstItem="Bae-lI-CIE" firstAttribute="width" secondItem="uaf-dz-Gf9" secondAttribute="width" id="aRI-tq-06X"/>
+                                                                    </constraints>
                                                                     <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                     </visibilityPriorities>
                                                                     <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
@@ -816,20 +833,20 @@
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="PLF-x4-bMC">
                                                                     <rect key="frame" x="0.0" y="20" width="360" height="140"/>
                                                                     <subviews>
-                                                                        <stackView distribution="equalCentering" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="K2Z-nI-3Oq">
+                                                                        <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="K2Z-nI-3Oq">
                                                                             <rect key="frame" x="20" y="0.0" width="263" height="140"/>
-                                                                            <subviews>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-J9-1NW">
+                                                                            <beginningViews>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-J9-1NW">
                                                                                     <rect key="frame" x="0.0" y="0.0" width="28" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
                                                                                             <rect key="frame" x="5.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="Twm-2U-8ou"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
                                                                                             <rect key="frame" x="-2" y="0.0" width="32" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -837,7 +854,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -847,17 +864,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="e12-8n-EpU">
-                                                                                    <rect key="frame" x="28.5" y="0.0" width="24" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sHK-zw-tFa">
+                                                                                    <rect key="frame" x="28" y="0.0" width="59" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e12-8n-EpU">
+                                                                                    <rect key="frame" x="87" y="0.0" width="24" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
                                                                                             <rect key="frame" x="3.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="SCy-Om-bV6"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
                                                                                             <rect key="frame" x="-2" y="0.0" width="28" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -865,7 +885,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -875,17 +895,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="8Vo-in-EfA">
-                                                                                    <rect key="frame" x="57" y="0.0" width="20" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ccm-o6-iBe">
+                                                                                    <rect key="frame" x="111" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Vo-in-EfA">
+                                                                                    <rect key="frame" x="111" y="0.0" width="20" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
                                                                                             <rect key="frame" x="1.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="a7E-4j-6g2"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
                                                                                             <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -893,7 +916,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -903,17 +926,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="uEN-an-lH8">
-                                                                                    <rect key="frame" x="82.5" y="0.0" width="22" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UFW-iM-FFP">
+                                                                                    <rect key="frame" x="131" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uEN-an-lH8">
+                                                                                    <rect key="frame" x="131" y="0.0" width="22" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
                                                                                             <rect key="frame" x="2.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TbE-dB-ORk"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
                                                                                             <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -921,7 +947,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -931,17 +957,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="dzW-J4-19x">
-                                                                                    <rect key="frame" x="109" y="0.0" width="22" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4y2-Om-uhN">
+                                                                                    <rect key="frame" x="153" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dzW-J4-19x">
+                                                                                    <rect key="frame" x="153" y="0.0" width="22" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
                                                                                             <rect key="frame" x="2.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="4Ra-VR-yOK"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
                                                                                             <rect key="frame" x="-2" y="0.0" width="26" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -949,7 +978,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -959,17 +988,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="xeh-so-znx">
-                                                                                    <rect key="frame" x="138.5" y="0.0" width="17" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rYQ-Li-Alj">
+                                                                                    <rect key="frame" x="175" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xeh-so-znx">
+                                                                                    <rect key="frame" x="175" y="0.0" width="17" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
                                                                                             <rect key="frame" x="0.0" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="xV9-OM-MHq"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
                                                                                             <rect key="frame" x="-0.5" y="0.0" width="18" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -977,7 +1009,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -987,17 +1019,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="jhn-Sf-d6M">
-                                                                                    <rect key="frame" x="165" y="0.0" width="17" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ekq-xk-ZZJ">
+                                                                                    <rect key="frame" x="192" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jhn-Sf-d6M">
+                                                                                    <rect key="frame" x="192" y="0.0" width="17" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
                                                                                             <rect key="frame" x="0.0" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TNb-Es-VsX"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
                                                                                             <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1005,7 +1040,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -1015,17 +1050,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="bQP-M3-eeN">
-                                                                                    <rect key="frame" x="191.5" y="0.0" width="17" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LbE-J7-Ox5">
+                                                                                    <rect key="frame" x="209" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bQP-M3-eeN">
+                                                                                    <rect key="frame" x="209" y="0.0" width="17" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
                                                                                             <rect key="frame" x="0.0" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="P8O-pY-Nby"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
                                                                                             <rect key="frame" x="-1.5" y="0.0" width="20" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1033,7 +1071,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -1043,17 +1081,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="3ui-44-2iZ">
-                                                                                    <rect key="frame" x="218" y="0.0" width="17" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAr-fo-5xz">
+                                                                                    <rect key="frame" x="226" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3ui-44-2iZ">
+                                                                                    <rect key="frame" x="226" y="0.0" width="17" height="140"/>
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
                                                                                             <rect key="frame" x="0.0" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="GEq-jW-WUw"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
                                                                                             <rect key="frame" x="-1" y="0.0" width="19" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1061,7 +1102,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -1071,17 +1112,20 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                                <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="32z-9I-Hez">
+                                                                                <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m2J-NV-cjf">
+                                                                                    <rect key="frame" x="243" y="0.0" width="0.0" height="140"/>
+                                                                                </customView>
+                                                                                <stackView orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="32z-9I-Hez">
                                                                                     <rect key="frame" x="243" y="0.0" width="20" height="140"/>
-                                                                                    <subviews>
-                                                                                        <slider horizontalHuggingPriority="750" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
+                                                                                    <beginningViews>
+                                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
                                                                                             <rect key="frame" x="1.5" y="18" width="18" height="122"/>
                                                                                             <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="5FD-oT-GpE"/>
                                                                                             <connections>
                                                                                                 <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
                                                                                             </connections>
                                                                                         </slider>
-                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
+                                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
                                                                                             <rect key="frame" x="-2" y="0.0" width="24" height="11"/>
                                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
                                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1089,7 +1133,7 @@
                                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                             </textFieldCell>
                                                                                         </textField>
-                                                                                    </subviews>
+                                                                                    </beginningViews>
                                                                                     <visibilityPriorities>
                                                                                         <integer value="1000"/>
                                                                                         <integer value="1000"/>
@@ -1099,8 +1143,27 @@
                                                                                         <real value="3.4028234663852886e+38"/>
                                                                                     </customSpacing>
                                                                                 </stackView>
-                                                                            </subviews>
+                                                                            </beginningViews>
+                                                                            <constraints>
+                                                                                <constraint firstItem="UFW-iM-FFP" firstAttribute="width" secondItem="Ccm-o6-iBe" secondAttribute="width" id="3EH-I1-V6J"/>
+                                                                                <constraint firstItem="m2J-NV-cjf" firstAttribute="width" secondItem="jAr-fo-5xz" secondAttribute="width" id="KXv-kj-LWn"/>
+                                                                                <constraint firstItem="rYQ-Li-Alj" firstAttribute="width" secondItem="4y2-Om-uhN" secondAttribute="width" id="R1g-ZU-PHG"/>
+                                                                                <constraint firstItem="Ekq-xk-ZZJ" firstAttribute="width" secondItem="rYQ-Li-Alj" secondAttribute="width" id="Ssk-Rp-UT9"/>
+                                                                                <constraint firstItem="jAr-fo-5xz" firstAttribute="width" secondItem="LbE-J7-Ox5" secondAttribute="width" id="caZ-Ed-Cyq"/>
+                                                                                <constraint firstItem="LbE-J7-Ox5" firstAttribute="width" secondItem="Ekq-xk-ZZJ" secondAttribute="width" id="gCt-LQ-eFT"/>
+                                                                                <constraint firstItem="4y2-Om-uhN" firstAttribute="width" secondItem="UFW-iM-FFP" secondAttribute="width" id="nZ5-nf-kqh"/>
+                                                                                <constraint firstItem="Ccm-o6-iBe" firstAttribute="width" secondItem="sHK-zw-tFa" secondAttribute="width" id="xU4-AV-IFt"/>
+                                                                            </constraints>
                                                                             <visibilityPriorities>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
                                                                                 <integer value="1000"/>
                                                                                 <integer value="1000"/>
                                                                                 <integer value="1000"/>
@@ -1113,6 +1176,15 @@
                                                                                 <integer value="1000"/>
                                                                             </visibilityPriorities>
                                                                             <customSpacing>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
@@ -1125,10 +1197,10 @@
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                             </customSpacing>
                                                                         </stackView>
-                                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="trailing" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="FqD-Ht-R76">
+                                                                        <stackView orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="FqD-Ht-R76">
                                                                             <rect key="frame" x="303" y="20" width="37" height="112"/>
-                                                                            <subviews>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
+                                                                            <beginningViews>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
                                                                                     <rect key="frame" x="-2" y="98" width="41" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+12 dB" id="4BZ-H1-GEU">
                                                                                         <font key="font" metaFont="smallSystem"/>
@@ -1136,29 +1208,42 @@
                                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                     </textFieldCell>
                                                                                 </textField>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
-                                                                                    <rect key="frame" x="10" y="49" width="29" height="14"/>
+                                                                                <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ixi-lk-2aY">
+                                                                                    <rect key="frame" x="0.0" y="28" width="37" height="70"/>
+                                                                                </customView>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
+                                                                                    <rect key="frame" x="-2" y="14" width="29" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0 dB" id="lBn-YS-jL7">
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                     </textFieldCell>
                                                                                 </textField>
-                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="39" height="14"/>
+                                                                                <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QXY-J5-Bxa">
+                                                                                    <rect key="frame" x="0.0" y="14" width="37" height="0.0"/>
+                                                                                </customView>
+                                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
+                                                                                    <rect key="frame" x="-2" y="0.0" width="39" height="14"/>
                                                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-12 dB" id="Lpw-ws-Ezh">
                                                                                         <font key="font" metaFont="smallSystem"/>
                                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                     </textFieldCell>
                                                                                 </textField>
-                                                                            </subviews>
+                                                                            </beginningViews>
+                                                                            <constraints>
+                                                                                <constraint firstItem="QXY-J5-Bxa" firstAttribute="height" secondItem="ixi-lk-2aY" secondAttribute="height" id="Mi1-KC-YU6"/>
+                                                                            </constraints>
                                                                             <visibilityPriorities>
+                                                                                <integer value="1000"/>
+                                                                                <integer value="1000"/>
                                                                                 <integer value="1000"/>
                                                                                 <integer value="1000"/>
                                                                                 <integer value="1000"/>
                                                                             </visibilityPriorities>
                                                                             <customSpacing>
+                                                                                <real value="3.4028234663852886e+38"/>
+                                                                                <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
                                                                                 <real value="3.4028234663852886e+38"/>
@@ -1440,10 +1525,10 @@
                                                                         <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <stackView distribution="equalCentering" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="feR-n9-dpN">
+                                                                <stackView orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="feR-n9-dpN">
                                                                     <rect key="frame" x="20" y="27" width="248" height="11"/>
-                                                                    <subviews>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
+                                                                    <beginningViews>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
                                                                             <rect key="frame" x="-2" y="0.0" width="20" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1451,15 +1536,21 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                            <rect key="frame" x="114.5" y="0.0" width="19" height="11"/>
+                                                                        <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P2D-Jk-ikd">
+                                                                            <rect key="frame" x="24" y="0.0" width="168" height="11"/>
+                                                                        </customView>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
+                                                                            <rect key="frame" x="198" y="0.0" width="19" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
                                                                                 <font key="font" metaFont="miniSystem"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
+                                                                        <customView horizontalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JTL-na-jiR">
+                                                                            <rect key="frame" x="223" y="0.0" width="0.0" height="11"/>
+                                                                        </customView>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
                                                                             <rect key="frame" x="229" y="0.0" width="21" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
                                                                                 <font key="font" metaFont="miniSystem"/>
@@ -1467,13 +1558,20 @@
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                    </subviews>
+                                                                    </beginningViews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="JTL-na-jiR" firstAttribute="width" secondItem="P2D-Jk-ikd" secondAttribute="width" id="rja-tM-Lt5"/>
+                                                                    </constraints>
                                                                     <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                         <integer value="1000"/>
                                                                     </visibilityPriorities>
                                                                     <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
                                                                         <real value="3.4028234663852886e+38"/>
@@ -1589,9 +1687,6 @@
                                                                 </textField>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR">
                                                                     <rect key="frame" x="18" y="304" width="324" height="28"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="320" id="TJx-rX-qcD"/>
-                                                                    </constraints>
                                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Sub style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
                                                                         <font key="font" metaFont="smallSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1949,7 +2044,7 @@
                 <constraint firstItem="rH3-pU-mFc" firstAttribute="leading" secondItem="3Fk-ey-FhK" secondAttribute="trailing" id="zbP-4C-atO"/>
                 <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="3Fk-ey-FhK" secondAttribute="bottom" id="zzU-O5-6j9"/>
             </constraints>
-            <point key="canvasLocation" x="2782.5" y="149.5"/>
+            <point key="canvasLocation" x="2782" y="149.5"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -27,6 +27,7 @@
                 <outlet property="audioTabBtn" destination="3Fk-ey-FhK" id="I1P-Dg-gtv"/>
                 <outlet property="audioTableView" destination="FLg-2m-Zaq" id="rId-Io-Y2B"/>
                 <outlet property="brightnessSlider" destination="sBU-NZ-sp3" id="IWR-1I-CcR"/>
+                <outlet property="buttonTopConstraint" destination="86G-SF-ekk" id="T0q-y5-GEU"/>
                 <outlet property="contrastSlider" destination="0Ww-YT-a8e" id="wNQ-VI-uMd"/>
                 <outlet property="cropSegment" destination="kUi-hW-BR6" id="fsg-We-n2K"/>
                 <outlet property="customAspectTextField" destination="XAI-y0-tcy" id="j96-rd-E5w"/>
@@ -57,6 +58,7 @@
                 <outlet property="subTextFontBtn" destination="qGz-rB-dsV" id="Xkg-P1-vDv"/>
                 <outlet property="subTextSizePopUp" destination="xtF-tn-m9W" id="62h-S6-9gV"/>
                 <outlet property="tabView" destination="udA-m2-eJb" id="zL4-73-AVP"/>
+                <outlet property="tabViewTopConstraint" destination="SrL-is-N20" id="FpM-Gl-use"/>
                 <outlet property="videoTabBtn" destination="Ma8-6g-tVw" id="d0g-Fi-gzz"/>
                 <outlet property="videoTableView" destination="rsV-qL-l7b" id="A8k-AU-noQ"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
@@ -655,7 +657,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
                                             <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="267" width="360" height="476"/>
@@ -675,7 +677,7 @@
                                                                     <rect key="frame" x="0.0" y="355" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="FLg-2m-Zaq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
@@ -762,7 +764,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
-                                                                    <rect key="frame" x="130.5" y="226" width="19" height="11"/>
+                                                                    <rect key="frame" x="130" y="226" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="wgA-op-JP4">
                                                                         <font key="font" metaFont="miniSystem"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1284,7 +1286,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
                                             <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="360" height="743"/>
@@ -1296,7 +1298,7 @@
                                                                     <rect key="frame" x="0.0" y="274" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="2vU-hm-gGB">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1352,7 +1354,7 @@
                                                                     <rect key="frame" x="0.0" y="157" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="Jve-qX-Agy">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -327,7 +327,6 @@ class MPVController: NSObject {
   func command(_ command: MPVCommand, args: [String?] = [], checkError: Bool = true, returnValueCallback: ((Int32) -> Void)? = nil) {
     if args.count > 0 && args.last == nil {
       Utility.fatal("Command do not need a nil suffix")
-      return
     }
 
     var strArgs = args

--- a/iina/MPVFilter.swift
+++ b/iina/MPVFilter.swift
@@ -91,7 +91,6 @@ class MPVFilter: NSObject {
   func cropParams(videoSize: NSSize) -> [String: Double] {
     guard type == .crop else {
       Utility.fatal("Trying to get crop params from a non-crop filter!")
-      return [:]
     }
     guard let params = params else { return [:] }
     // w and h should always valid

--- a/iina/MPVTrack.swift
+++ b/iina/MPVTrack.swift
@@ -17,14 +17,14 @@ class MPVTrack: NSObject {
   /** For binding a none track object to menu, id = 0 */
   static let noneSubTrack = MPVTrack(id: 0, type: .sub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
   /** For binding a none track object to menu, id = 0 */
-  static let noneSecongSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
+  static let noneSecondSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
 
   static func emptyTrack(_ type: TrackType) -> MPVTrack {
     switch type {
     case .video: return noneVideoTrack
     case .audio: return noneAudioTrack
     case .sub: return noneSubTrack
-    case .secondSub: return noneSecongSubTrack
+    case .secondSub: return noneSecondSubTrack
     }
 
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -161,9 +161,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   
   var titleTextField: NSTextField? {
     get {
-      // FIXME: Internal NSWindow API
-      return window?.perform(Selector(("_borderView")))?.takeUnretainedValue().perform(Selector(("_titleTextFieldView")))?.takeUnretainedValue() as? NSTextField
-//      return window?.standardWindowButton(.documentIconButton)?.superview?.subviews.flatMap({ $0 as? NSTextField }).first
+      return window?.standardWindowButton(.documentIconButton)?.superview?.subviews.flatMap({ $0 as? NSTextField }).first
     }
   }
   @IBOutlet weak var controlBar: ControlBarView!

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -542,11 +542,9 @@ class PlayerCore: NSObject {
   func fileLoaded() {
     guard let mw = mainWindow else {
       Utility.fatal("Window is nil at fileLoaded")
-      return
     }
     guard let vwidth = info.videoWidth, let vheight = info.videoHeight else {
       Utility.fatal("Cannot get video width and height")
-      return
     }
     invalidateTimer()
     triedUsingExactSeekForCurrentFile = false
@@ -581,7 +579,6 @@ class PlayerCore: NSObject {
     guard let mw = mainWindow else { return }
     guard let dwidth = info.displayWidth, let dheight = info.displayHeight else {
       Utility.fatal("Cannot get video width and height")
-      return
     }
     if dwidth != 0 && dheight != 0 {
       DispatchQueue.main.sync {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -141,7 +141,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDel
       playlistBtn.attributedTitle = NSAttributedString(string: playlistStr, attributes: Utility.tabTitleFontAttributes)
     }
   }
-  
+
   // MARK: - NSTableViewDataSource
 
   func numberOfRows(in tableView: NSTableView) -> Int {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDelegate {
+class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDelegate, SidebarViewController {
 
   override var nibName: String {
     return "PlaylistViewController"
@@ -39,6 +39,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDel
   @IBOutlet weak var playlistBtn: NSButton!
   @IBOutlet weak var chaptersBtn: NSButton!
   @IBOutlet weak var tabView: NSTabView!
+  @IBOutlet weak var buttonTopConstraint: NSLayoutConstraint!
   @IBOutlet weak var deleteBtn: NSButton!
   @IBOutlet weak var loopBtn: NSButton!
   @IBOutlet weak var shuffleBtn: NSButton!
@@ -50,6 +51,12 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDel
   lazy var chapterDelegate: ChapterTableDelegate = {
     return ChapterTableDelegate(self)
   }()
+  
+  var downShift: CGFloat = 0 {
+    didSet {
+      buttonTopConstraint.animator().constant = downShift
+    }
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -134,7 +141,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSMenuDel
       playlistBtn.attributedTitle = NSAttributedString(string: playlistStr, attributes: Utility.tabTitleFontAttributes)
     }
   }
-
+  
   // MARK: - NSTableViewDataSource
 
   func numberOfRows(in tableView: NSTableView) -> Int {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -79,7 +79,6 @@ class PrefKeyBindingViewController: NSViewController, MASPreferencesViewControll
     guard let uc = UserDefaults.standard.dictionary(forKey: Preference.Key.inputConfigs)
     else  {
       Utility.fatal("Cannot get config file list!")
-      return
     }
     userConfigs = uc
     userConfigs.forEach { (k, v) in

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -38,7 +38,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var subTabBtn: NSButton!
   @IBOutlet weak var tabView: NSTabView!
 
-	@IBOutlet weak var buttonTopConstraint: NSLayoutConstraint!
+  @IBOutlet weak var buttonTopConstraint: NSLayoutConstraint!
 	@IBOutlet weak var tabViewTopConstraint: NSLayoutConstraint!
 	
   @IBOutlet weak var videoTableView: NSTableView!
@@ -386,6 +386,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     let knobPos = sender.knobPointPosition()
     speedSliderConstraint.constant = knobPos - speedSliderIndicator.frame.width
     playerCore.setSpeed(value)
+    view.layout()
   }
 
   @IBAction func customSpeedEditFinishedAction(_ sender: NSTextField) {
@@ -400,6 +401,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     if let window = sender.window {
       window.makeFirstResponder(window.contentView)
     }
+    speedSliderConstraint.constant = speedSlider.knobPointPosition() - speedSliderIndicator.frame.width
+    view.layout()
   }
 
   @IBAction func deinterlaceBtnAction(_ sender: AnyObject) {
@@ -479,6 +482,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
         playerCore.setAudioDelay(sliderValue)
       }
     }
+    view.layout()
   }
 
   @IBAction func customAudioDelayEditFinishedAction(_ sender: AnyObject?) {
@@ -531,6 +535,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
         customSubDelayTextField.doubleValue = sliderValue
       }
     }
+    view.layout()
   }
 
   @IBAction func customSubDelayEditFinishedAction(_ sender: AnyObject?) {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
+class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, SidebarViewController {
 
   override var nibName: String {
     return "QuickSettingViewController"
@@ -38,6 +38,9 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var subTabBtn: NSButton!
   @IBOutlet weak var tabView: NSTabView!
 
+	@IBOutlet weak var buttonTopConstraint: NSLayoutConstraint!
+	@IBOutlet weak var tabViewTopConstraint: NSLayoutConstraint!
+	
   @IBOutlet weak var videoTableView: NSTableView!
   @IBOutlet weak var audioTableView: NSTableView!
   @IBOutlet weak var subTableView: NSTableView!
@@ -95,8 +98,12 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var subTextBgColorWell: NSColorWell!
   @IBOutlet weak var subTextFontBtn: NSButton!
 
-
-
+  var downShift: CGFloat = 0 {
+    didSet {
+      buttonTopConstraint.animator().constant = downShift
+      tabViewTopConstraint.animator().constant = 48 + downShift
+    }
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -43,12 +43,16 @@ class Utility {
     }
   }
 
-  static func fatal(_ message: String, _ block: () -> Void = {}) {
+  static func fatal(_ message: String, _ block: () -> Void = {}) -> Never {
     NSLog("%@", message)
     NSLog(Thread.callStackSymbols.joined(separator: "\n"))
     showAlert(message: "Fatal error: \(message) \nThe application will exit now.")
     block()
-    exit(1)
+    // Make sure the application exits
+    DispatchQueue.main.sync {
+      fatalError()
+    }
+    fatalError()
   }
 
   // MARK: - Panels, Alerts

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -15,7 +15,6 @@ fileprivate func mpvGetOpenGL(_ ctx: UnsafeMutableRawPointer?, _ name: UnsafePoi
   let symbolName: CFString = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingASCII);
   guard let addr = CFBundleGetFunctionPointerForName(CFBundleGetBundleWithIdentifier(CFStringCreateCopy(kCFAllocatorDefault, "com.apple.opengl" as CFString!)), symbolName) else {
     Utility.fatal("Cannot get OpenGL function pointer!")
-    return nil
   }
   return addr
 }


### PR DESCRIPTION
- [X] This change has been discussed with the author (at least, it's been mentioned many times)
- [x] It implements / fixes issue #315, #353.

---

**Description:**
A proper fix for both issues outlined above.  Please test it out, especially with long filenames and the fullscreen transition.

Caveats:
* This PR uses internal APIs. Essentially, `NSWindow` keeps changing the `NSTextField` for the title whenever switching between fullscreen and windowed mode. It also doesn't make the actual text field publicly available. Thus, the two solutions to accessing it are the API I used or iterating through `window.standardWindowButtons(.documentIcon).superview.subviews` for a `NSTextField`. Your choice on which one we use.
* I removed a line in `windowWillExitFullScreen` for reverting the appearance; I don't see what its purpose is. Please take a look to see if it's important.
* There is are fundamental issues with the layering of the views in `MainWindowController` that will require a lot of work to fix. I've left it alone for now, but we will need to take a look at it sometime.