### PR TITLE
Accept dragged strings and URLs on icon, fix #294 (part 2), fix #374

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   var isReady: Bool = false
   var handledDroppedText: Bool = false
+  var handledURLEvent: Bool = false
 
   var pendingURL: String?
 
@@ -144,7 +145,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func checkServiceStartup() {
-    if !handledDroppedText {
+    if !handledDroppedText && !handledURLEvent {
       openFile(self)
     }
   }
@@ -159,6 +160,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   // MARK: - URL Scheme
 
   func handleURLEvent(event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
+    handledURLEvent = true
     guard let url = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue else { return }
     if isReady {
       parsePendingURL(url)

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -13,7 +13,7 @@ import MASPreferences
 class AppDelegate: NSObject, NSApplicationDelegate {
 
   var isReady: Bool = false
-  var isServiceStartup: Bool = false
+  var handledDroppedText: Bool = false
 
   var pendingURL: String?
 
@@ -68,7 +68,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
       if UserDefaults.standard.bool(forKey: Preference.Key.openStartPanel) {
         // invoke after 0.5s
-        Timer.scheduledTimer(timeInterval: TimeInterval(0.5), target: self, selector: #selector(self.judgeServiceStartup), userInfo: nil, repeats: false)
+        Timer.scheduledTimer(timeInterval: TimeInterval(0.5), target: self, selector: #selector(self.checkServiceStartup), userInfo: nil, repeats: false)
       }
     }
 
@@ -138,13 +138,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   func droppedText(_ pboard: NSPasteboard, userData:String, error: NSErrorPointer) {
     if let url = pboard.string(forType: NSStringPboardType) {
-      isServiceStartup = true
+      handledDroppedText = true
       playerCore.openURLString(url)
     }
   }
 
-  func judgeServiceStartup() {
-    if !isServiceStartup {
+  func checkServiceStartup() {
+    if !handledDroppedText {
       openFile(self)
     }
   }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -13,6 +13,7 @@ import MASPreferences
 class AppDelegate: NSObject, NSApplicationDelegate {
 
   var isReady: Bool = false
+  var isServiceStartup: Bool = false
 
   var pendingURL: String?
 
@@ -67,7 +68,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
       if UserDefaults.standard.bool(forKey: Preference.Key.openStartPanel) {
         // invoke after 0.5s
-        Timer.scheduledTimer(timeInterval: TimeInterval(0.5), target: self, selector: #selector(self.openFile(_:)), userInfo: nil, repeats: false)
+        Timer.scheduledTimer(timeInterval: TimeInterval(0.5), target: self, selector: #selector(self.judgeServiceStartup), userInfo: nil, repeats: false)
       }
     }
 
@@ -87,6 +88,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if let url = pendingURL {
       parsePendingURL(url)
     }
+
+    NSApplication.shared().servicesProvider = self
   }
 
   func applicationWillTerminate(_ aNotification: Notification) {
@@ -131,6 +134,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     return true
   }
 
+  // MARK: - Accept dropped string and URL
+
+  func droppedText(_ pboard: NSPasteboard, userData:String, error: NSErrorPointer) {
+    if let url = pboard.string(forType: NSStringPboardType) {
+      isServiceStartup = true
+      playerCore.openURLString(url)
+    }
+  }
+
+  func judgeServiceStartup() {
+    if !isServiceStartup {
+      openFile(self)
+    }
+  }
+  
   // MARK: - Dock menu
 
   func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>NSMessage</key>
+			<string>droppedText</string>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Text Drop</string>
+			</dict>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
Accept dropped strings and URLs on IINA icon.

- [x] It implements issue #294 (part 2) & #374 .
- [x] This change has been discussed with the author.

---

**Description:**
Idea by http://stackoverflow.com/questions/27420016/osx-drag-and-drop-text-not-file-to-app-dock-icon .

I used a quite 'dirty' way to prevent the open panel. I call a new method instead of `openFile(_:)` after 0.5s to judge if I have to open the panel. Because system call `applicationWillFinishLaunching(_:)` first. At that time, I have no idea about how to know whether the app opened by the accept dropping service or not.

This pull request also prevents the open panel from showing up when the app is called by the browser extension.