### PR TITLE
Connect more mpv window options

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -81,6 +81,7 @@ struct Constants {
     static let vfChanged = Notification.Name("IINAVfChanged")
     static let afChanged = Notification.Name("IINAAfChanged")
     static let fsChanged = Notification.Name("IINAFullscreenChanged")
+    static let ontopChanged = Notification.Name("IINAOnTopChanged")
     static let keyBindingInputChanged = Notification.Name("IINAkeyBindingInputChanged")
     static let fileLoaded = Notification.Name("IINAFileLoaded")
   }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -58,7 +58,8 @@ class MPVController: NSObject {
     MPVOption.Equalizer.gamma: MPV_FORMAT_INT64,
     MPVOption.Equalizer.hue: MPV_FORMAT_INT64,
     MPVOption.Equalizer.saturation: MPV_FORMAT_INT64,
-    MPVOption.Window.fullscreen: MPV_FORMAT_FLAG
+    MPVOption.Window.fullscreen: MPV_FORMAT_FLAG,
+    MPVOption.Window.ontop: MPV_FORMAT_FLAG
   ]
 
   deinit {
@@ -741,6 +742,9 @@ class MPVController: NSObject {
 
     case MPVOption.Window.fullscreen:
       NotificationCenter.default.post(Notification(name: Constants.Noti.fsChanged))
+
+    case MPVOption.Window.ontop:
+      NotificationCenter.default.post(Notification(name: Constants.Noti.ontopChanged))
 
     // ignore following
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -83,7 +83,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   var isOntop: Bool = false {
     didSet {
       playerCore.mpvController.setFlag(MPVOption.Window.ontop, isOntop)
-
     }
   }
 

--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -206,8 +206,8 @@ extension MainWindowController {
   }
 
   @IBAction func menuAlwaysOnTop(_ sender: AnyObject) {
-    playerCore.info.isAlwaysOntop = !playerCore.info.isAlwaysOntop
-    setWindowFloatingOnTop(playerCore.info.isAlwaysOntop)
+    isOntop = !isOntop
+    setWindowFloatingOnTop(isOntop)
   }
   
   @available(macOS 10.12, *)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -305,7 +305,8 @@ class MenuController: NSObject, NSMenuDelegate {
   private func updateVideoMenu() {
     let isInFullScreen = PlayerCore.shared.mainWindow?.isInFullScreen ?? false
     let isInPIP = PlayerCore.shared.mainWindow?.isInPIP ?? false
-    alwaysOnTop.state = PlayerCore.shared.info.isAlwaysOntop ? NSOnState : NSOffState
+    let isOntop = PlayerCore.shared.mainWindow?.isOntop ?? false
+    alwaysOnTop.state = isOntop ? NSOnState : NSOffState
     deinterlace.state = PlayerCore.shared.info.deinterlace ? NSOnState : NSOffState
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -21,8 +21,6 @@ class PlaybackInfo {
   var displayWidth: Int?
   var displayHeight: Int?
 
-  var isAlwaysOntop: Bool = false
-
   var rotation: Int = 0
 
   var videoPosition: VideoTime?

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -533,6 +533,27 @@ class PlayerCore: NSObject {
     mpvController.command(.writeWatchLaterConfig)
   }
 
+  struct GeometryDef {
+    var x: String?, y: String?, w: String?, h: String?, xSign: String?, ySign: String?
+  }
+
+  func getGeometry() -> GeometryDef? {
+    let geometry = mpvController.getString(MPVOption.Window.geometry) ?? ""
+    // guard option value
+    guard !geometry.isEmpty else { return nil }
+    // match the string, replace empty group by nil
+    let captures: [String?] = Regex.geometry.captures(in: geometry).map { $0.isEmpty ? nil : $0 }
+    // guard matches
+    guard captures.count == 10 else { return nil }
+    // return struct
+    return GeometryDef(x: captures[7],
+                       y: captures[9],
+                       w: captures[2],
+                       h: captures[4],
+                       xSign: captures[6],
+                       ySign: captures[8])
+  }
+
   // MARK: - Other
 
   func fileStarted() {

--- a/iina/Regex.swift
+++ b/iina/Regex.swift
@@ -15,6 +15,7 @@ class Regex {
   static let tagVersion = Regex("\\Av(\\d+\\.\\d+\\.\\d+)\\Z")
   static let urlDetect = Regex("^(https?|ftp)://[^\\s/$.?#].[^\\s]*$")
   static let iso639_2Desc = Regex("^.+?\\(([a-z]{3})\\)$")
+  static let geometry = Regex("^((\\d+%?)?(x(\\d+%?))?)?((\\+|\\-)(\\d+%?)(\\+|\\-)(\\d+%?))?$")
 
   var regex: NSRegularExpression?
 
@@ -38,7 +39,12 @@ class Regex {
     var result: [String] = []
     if let match = regex?.firstMatch(in: str, options: [], range: NSMakeRange(0, str.characters.count)) {
       for i in 0..<match.numberOfRanges {
-        result.append((str as NSString).substring(with: match.rangeAt(i)))
+        let range = match.rangeAt(i)
+        if range.length > 0 {
+          result.append((str as NSString).substring(with: match.rangeAt(i)))
+        } else {
+          result.append("")
+        }
       }
     }
     return result


### PR DESCRIPTION
`ontop`

- window's floating on top status should be syn ced with mpv's `ontop` property.
- able to set key bindings for `ontop` (e.g. `cycle ontop` `set ontop yes`).
- options like `ontop=yes` should work initially

`geometry`

- see [mpv's doc](https://mpv.io/manual/stable/#options-geometry) and test whether it works normally.
- make sure it doesn't break any existing function.