### PR TITLE
Use DAR on file load

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -588,7 +588,7 @@ class PlayerCore: NSObject {
     guard let mw = mainWindow else {
       Utility.fatal("Window is nil at fileLoaded")
     }
-    guard let vwidth = info.videoWidth, let vheight = info.videoHeight else {
+    guard let vwidth = info.displayWidth, let vheight = info.displayHeight else {
       Utility.fatal("Cannot get video width and height")
     }
     invalidateTimer()


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
A quick bug fix, reported from telegram group: Videos with anamorphic (non-square) pixels would be played using SAR(Sample Aspect Ratio) on file load instead of DAR(Display Aspect Ratio).

I'm not able to always reproduce it: sometimes it stuck at SAR, sometimes it would jump from SAR to DAR. This commit let the program use DAR on file load.

Even with the commit, player would still use SAR on load for a moment, then resize to DAR size. Breakpoint on file load shows that mpv wouldn't report correct display width on the beginning. Maybe this commit fixes _nothing_. More tests are needed.