### PR TITLE
Fixed at exit crashes during playback

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -453,9 +453,6 @@ class MPVController: NSObject {
     case MPV_EVENT_SHUTDOWN:
       let quitByMPV = !playerCore.isMpvTerminated
       if quitByMPV {
-        playerCore.terminateMPV(sendQuit: false)
-        mpv_detach_destroy(mpv)
-        mpv = nil
         NSApp.terminate(nil)
       } else {
         mpv_detach_destroy(mpv)

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -66,14 +66,17 @@ class VideoView: NSView {
   }
 
   func uninit() {
-    guard !isUninited else { return }
-
     uninitLock.lock()
+    
+    guard !isUninited else {
+      uninitLock.unlock()
+      return
+    }
+    
     mpv_opengl_cb_set_update_callback(mpvGLContext, nil, nil)
     mpv_opengl_cb_uninit_gl(mpvGLContext)
-    uninitLock.unlock()
-
     isUninited = true
+    uninitLock.unlock()
   }
 
   deinit {

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -127,10 +127,13 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   override func draw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj, forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) {
-
-    guard !videoView.isUninited else { return }
-
     videoView.uninitLock.lock()
+    
+    guard !videoView.isUninited else {
+      videoView.uninitLock.unlock()
+      return
+    }
+    
     CGLLockContext(ctx)
     CGLSetCurrentContext(ctx)
 


### PR DESCRIPTION
**Description:**
You have mistakes in handling thread synchronisation allowing OpenGL context to be destroyed in the middle of the draw procedure. As a result closing the window during video playback will cause crashes.

This change reworks the way uninitLock is used and eliminates the race condition.