### PR TITLE
Fixed typo in Base Localizable.strings

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -161,7 +161,7 @@
 "alert.add_watch.message" = "Please enter a valid MPV property name.";
 
 "alert.jump_to.title" = "Jump to";
-"alert.jump_to.message" = "Please enter the time you want to jumo to. Example: 20:35";
+"alert.jump_to.message" = "Please enter the time you want to jump to. Example: 20:35";
 
 "alert.opensub.login.title" = "Opensubtitles Login";
 "alert.opensub.login.message" = "Please enter your username and password";


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

I found a liitle typo in Localizable.strings(Base).