### PR TITLE
Redraw on audio file resize (cover display issue)

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1081,8 +1081,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   func windowDidResize(_ notification: Notification) {
     guard let w = window else { return }
     let wSize = w.frame.size
-    // is paused, draw new frame
-    if playerCore.info.isPaused {
+    // is paused or very low fps (assume audio file), draw new frame
+    if playerCore.info.isPaused || playerCore.mpvController.getDouble(MPVProperty.estimatedVfFps) < 1 {
       videoView.videoLayer.draw()
     }
 


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
IINA was not redrawing the album cover on resize when playing audio files, There were a resize on launch so lower resolution cover gets directly stretched.

We assume that current render fps < 1 == playing audio file, and redraw on resize notif.