### PR TITLE
Animation fix

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -144,6 +144,8 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   }
 
   var wasPlayingWhenSeekBegan: Bool?
+  
+  var mouseExitEnterCount = 0
 
   // MARK: - Enums
 
@@ -770,6 +772,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
           } else {
             // else start a timer
             singleClickTimer = Timer.scheduledTimer(timeInterval: NSEvent.doubleClickInterval(), target: self, selector: #selector(self.performMouseActionLater(_:)), userInfo: singleClickAction, repeats: false)
+            mouseExitEnterCount = 0
           }
         } else if event.clickCount == 2 {
           // double click
@@ -793,6 +796,11 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
   @objc private func performMouseActionLater(_ timer: Timer) {
     guard let action = timer.userInfo as? Preference.MouseClickAction else { return }
+    if mouseExitEnterCount >= 2 && action == .hideOSC {
+      // the counter being greater than or equal to 2 means that the mouse re-entered the window
+      // showUI() must be called due to the movement in the window, thus hideOSC action should be cancelled
+      return
+    }
     performMouseAction(action)
   }
 
@@ -818,6 +826,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       Utility.log("No data for tracking area")
       return
     }
+    mouseExitEnterCount += 1
     if obj == 0 {
       // main window
       isMouseInWindow = true
@@ -840,6 +849,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       Utility.log("No data for tracking area")
       return
     }
+    mouseExitEnterCount += 1
     if obj == 0 {
       // main window
       isMouseInWindow = false

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1196,6 +1196,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }
     
     animationState = .willHide
+    fadeableViews.forEach { (v) in
+      v.isHidden = false
+    }
     standardWindowButtons.forEach { $0.isEnabled = false }
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = UIAnimationDuration
@@ -1208,6 +1211,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }) {
       // if no interrupt then hide animation
       if self.animationState == .willHide {
+        self.fadeableViews.forEach { (v) in
+          v.isHidden = true
+        }
         self.animationState = .hidden
       }
     }
@@ -1215,6 +1221,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
   private func showUI() {
     animationState = .willShow
+    fadeableViews.forEach { (v) in
+      v.isHidden = false
+    }
     standardWindowButtons.forEach { $0.isEnabled = true }
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = UIAnimationDuration

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -20,10 +20,10 @@ fileprivate let OSCTopMainViewMarginTopInFullScreen: CGFloat = 6
 fileprivate let PlaylistMinWidth: CGFloat = 240
 fileprivate let PlaylistMaxWidth: CGFloat = 400
 
-fileprivate let UIAnimationDuration: TimeInterval = 0.25
-fileprivate let OSDAnimationDuration: TimeInterval = 0.5
-fileprivate let SideBarAnimationDuration: TimeInterval = 0.2
-fileprivate let CropAnimationDuration: TimeInterval = 0.2
+fileprivate let UIAnimationDuration = 0.25
+fileprivate let OSDAnimationDuration = 0.5
+fileprivate let SideBarAnimationDuration = 0.2
+fileprivate let CropAnimationDuration = 0.2
 
 class MainWindowController: NSWindowController, NSWindowDelegate {
 


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

This pull request refactors `hideUI()` and `showUI()` in MainWindowController. In principle, I made those two functions symmetrical.

```diff
     fadeableViews.forEach { (v) in
-      v.alphaValue = 1
       v.isHidden = false
     }
```
`alphaValue` is managed by the animator. Change it manually is useless and somewhat invalid.
```diff
+    standardWindowButtons.forEach { $0.isEnabled = false }
```
Should be disabled.
```diff
-      self.animationState = .shown
+      // if no interrupt then hide animation
+      if self.animationState == .willShow {
+        self.animationState = .shown
+      }
```
Like `hideUI()`, `showUI()` should also be able to be interrupted by `hideUI()`.

```diff
-    if isMouseInWindow && animationState == .hidden {
+    if isMouseInWindow {
       showUI()
```
Whatever `animationState` is, we should call `showUI()` directly. `showUI()` can interrupt `hideUI()` effectively.

```diff
+    if mouseExitEnterCount >= 2 && action == .hideOSC {
+      // the counter being greater than or equal to 2 means that the mouse re-entered the window
+      // showUI() must be called due to the movement in the window, thus hideOSC action should be cancelled
+      return
+    }
```
These code fixed a bug. You can reproduce it by steps below:
- Make sure `NSEvent.doubleClickInterval()` have some value.
- Make single click action to be "Hide OSC".
- Click once in the window.
- Move the mouse out and in the window then stop there (quickly!).
- OSC should be shown due to the mouse movement in the window, however "Hide OSC" is activated after show OSC. OSC is hidden.