### PR TITLE
MediaPlayer framework

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -451,55 +451,55 @@ class RemoteCommandController {
   static var useSystemMediaControl: Bool = false
 
   static func setup() {
-    remoteCommand.playCommand.addTarget(handler: { _ in
+    remoteCommand.playCommand.addTarget { _ in
       PlayerCore.lastActive.togglePause(false)
       return .success
-    })
-    remoteCommand.pauseCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.pauseCommand.addTarget { _ in
       PlayerCore.lastActive.togglePause(true)
       return .success
-    })
-    remoteCommand.togglePlayPauseCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.togglePlayPauseCommand.addTarget { _ in
       PlayerCore.lastActive.togglePause(nil)
       return .success
-    })
-    remoteCommand.stopCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.stopCommand.addTarget { _ in
       PlayerCore.lastActive.stop()
       return .success
-    })
-    remoteCommand.nextTrackCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.nextTrackCommand.addTarget { _ in
       PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: true)
       return .success
-    })
-    remoteCommand.previousTrackCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.previousTrackCommand.addTarget { _ in
       PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: false)
       return .success
-    })
-    remoteCommand.changeRepeatModeCommand.addTarget(handler: { _ in
+    }
+    remoteCommand.changeRepeatModeCommand.addTarget { _ in
       PlayerCore.lastActive.togglePlaylistLoop()
       return .success
-    })
+    }
     remoteCommand.changeShuffleModeCommand.isEnabled = false
-    // remoteCommand.changeShuffleModeCommand.addTarget(handler: {})
+    // remoteCommand.changeShuffleModeCommand.addTarget {})
     remoteCommand.changePlaybackRateCommand.supportedPlaybackRates = [0.5, 1, 1.5, 2]
-    remoteCommand.changePlaybackRateCommand.addTarget(handler: { event in
+    remoteCommand.changePlaybackRateCommand.addTarget { event in
       PlayerCore.lastActive.setSpeed(Double((event as! MPChangePlaybackRateCommandEvent).playbackRate))
       return .success
-    })
+    }
     remoteCommand.skipForwardCommand.preferredIntervals = [15]
-    remoteCommand.skipForwardCommand.addTarget(handler: { event in
+    remoteCommand.skipForwardCommand.addTarget { event in
       PlayerCore.lastActive.seek(relativeSecond: (event as! MPSkipIntervalCommandEvent).interval, option: .exact)
       return .success
-    })
-    remoteCommand.skipBackwardCommand.preferredIntervals = [30]
-    remoteCommand.skipBackwardCommand.addTarget(handler: { event in
+    }
+    remoteCommand.skipBackwardCommand.preferredIntervals = [15]
+    remoteCommand.skipBackwardCommand.addTarget { event in
       PlayerCore.lastActive.seek(relativeSecond: -(event as! MPSkipIntervalCommandEvent).interval, option: .exact)
       return .success
-    })
-    remoteCommand.changePlaybackPositionCommand.addTarget(handler: { event in
+    }
+    remoteCommand.changePlaybackPositionCommand.addTarget { event in
       PlayerCore.lastActive.seek(absoluteSecond: (event as! MPChangePlaybackPositionCommandEvent).positionTime)
       return .success
-    })
+    }
   }
 
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -451,11 +451,55 @@ class RemoteCommandController {
   static var useSystemMediaControl: Bool = false
 
   static func setup() {
-    remoteCommand.playCommand.addTarget(handler: PlayerCore.handlePlayCommand(_:))
-    remoteCommand.pauseCommand.addTarget(handler: PlayerCore.handlePauseCommand(_:))
-    remoteCommand.togglePlayPauseCommand.addTarget(handler: PlayerCore.handleTogglePlayPauseCommand(_:))
-    remoteCommand.stopCommand.addTarget(handler: PlayerCore.handleStopCommand(_:))
-    remoteCommand.nextTrackCommand.addTarget(handler: PlayerCore.handleNextTrackCommand(_:))
-    remoteCommand.previousTrackCommand.addTarget(handler: PlayerCore.handlePreviousTrackCommand(_:))
+    remoteCommand.playCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.togglePause(false)
+      return .success
+    })
+    remoteCommand.pauseCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.togglePause(true)
+      return .success
+    })
+    remoteCommand.togglePlayPauseCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.togglePause(nil)
+      return .success
+    })
+    remoteCommand.stopCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.stop()
+      return .success
+    })
+    remoteCommand.nextTrackCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: true)
+      return .success
+    })
+    remoteCommand.previousTrackCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: false)
+      return .success
+    })
+    remoteCommand.changeRepeatModeCommand.addTarget(handler: { _ in
+      PlayerCore.lastActive.togglePlaylistLoop()
+      return .success
+    })
+    remoteCommand.changeShuffleModeCommand.isEnabled = false
+    // remoteCommand.changeShuffleModeCommand.addTarget(handler: {})
+    remoteCommand.changePlaybackRateCommand.supportedPlaybackRates = [0.5, 1, 1.5, 2]
+    remoteCommand.changePlaybackRateCommand.addTarget(handler: { event in
+      PlayerCore.lastActive.setSpeed(Double((event as! MPChangePlaybackRateCommandEvent).playbackRate))
+      return .success
+    })
+    remoteCommand.skipForwardCommand.preferredIntervals = [15]
+    remoteCommand.skipForwardCommand.addTarget(handler: { event in
+      PlayerCore.lastActive.seek(relativeSecond: (event as! MPSkipIntervalCommandEvent).interval, option: .exact)
+      return .success
+    })
+    remoteCommand.skipBackwardCommand.preferredIntervals = [30]
+    remoteCommand.skipBackwardCommand.addTarget(handler: { event in
+      PlayerCore.lastActive.seek(relativeSecond: -(event as! MPSkipIntervalCommandEvent).interval, option: .exact)
+      return .success
+    })
+    remoteCommand.changePlaybackPositionCommand.addTarget(handler: { event in
+      PlayerCore.lastActive.seek(absoluteSecond: (event as! MPChangePlaybackPositionCommandEvent).positionTime)
+      return .success
+    })
   }
+
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -147,6 +147,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       remoteCommand.stopCommand.addTarget(handler: PlayerCore.handleStopCommand(_:))
       remoteCommand.nextTrackCommand.addTarget(handler: PlayerCore.handleNextTrackCommand(_:))
       remoteCommand.previousTrackCommand.addTarget(handler: PlayerCore.handlePreviousTrackCommand(_:))
+
+      NowPlayingInfoManager.updateState(.unknown)
     }
 
     // if have pending open request

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -142,7 +142,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     if #available(macOS 10.13, *) {
-      RemoteCommandController.useSystemMediaControl = Preference.bool(for: .useMediaKeys)
       if RemoteCommandController.useSystemMediaControl {
         RemoteCommandController.setup()
         NowPlayingInfoManager.updateState(.unknown)
@@ -448,7 +447,7 @@ struct CommandLineStatus {
 class RemoteCommandController {
   static let remoteCommand = MPRemoteCommandCenter.shared()
 
-  static var useSystemMediaControl: Bool = false
+  static var useSystemMediaControl: Bool = Preference.bool(for: .useMediaKeys)
 
   static func setup() {
     remoteCommand.playCommand.addTarget { _ in

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import MediaPlayer
 import MASPreferences
 
 /** Max time interval for repeated `application(_:openFile:)` calls. */
@@ -138,6 +139,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if #available(macOS 10.12.2, *) {
       NSApp.isAutomaticCustomizeTouchBarMenuItemEnabled = false
       NSWindow.allowsAutomaticWindowTabbing = false
+
+      let remoteCommand = MPRemoteCommandCenter.shared()
+      remoteCommand.playCommand.addTarget(handler: PlayerCore.handlePlayCommand(_:))
+      remoteCommand.pauseCommand.addTarget(handler: PlayerCore.handlePauseCommand(_:))
+      remoteCommand.togglePlayPauseCommand.addTarget(handler: PlayerCore.handleTogglePlayPauseCommand(_:))
+      remoteCommand.stopCommand.addTarget(handler: PlayerCore.handleStopCommand(_:))
+      remoteCommand.nextTrackCommand.addTarget(handler: PlayerCore.handleNextTrackCommand(_:))
+      remoteCommand.previousTrackCommand.addTarget(handler: PlayerCore.handlePreviousTrackCommand(_:))
     }
 
     // if have pending open request

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -139,16 +139,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if #available(macOS 10.12.2, *) {
       NSApp.isAutomaticCustomizeTouchBarMenuItemEnabled = false
       NSWindow.allowsAutomaticWindowTabbing = false
+    }
 
-      let remoteCommand = MPRemoteCommandCenter.shared()
-      remoteCommand.playCommand.addTarget(handler: PlayerCore.handlePlayCommand(_:))
-      remoteCommand.pauseCommand.addTarget(handler: PlayerCore.handlePauseCommand(_:))
-      remoteCommand.togglePlayPauseCommand.addTarget(handler: PlayerCore.handleTogglePlayPauseCommand(_:))
-      remoteCommand.stopCommand.addTarget(handler: PlayerCore.handleStopCommand(_:))
-      remoteCommand.nextTrackCommand.addTarget(handler: PlayerCore.handleNextTrackCommand(_:))
-      remoteCommand.previousTrackCommand.addTarget(handler: PlayerCore.handlePreviousTrackCommand(_:))
-
-      NowPlayingInfoManager.updateState(.unknown)
+    if #available(macOS 10.13, *) {
+      RemoteCommandController.useSystemMediaControl = Preference.bool(for: .useMediaKeys)
+      if RemoteCommandController.useSystemMediaControl {
+        RemoteCommandController.setup()
+        NowPlayingInfoManager.updateState(.unknown)
+      }
     }
 
     // if have pending open request
@@ -443,5 +441,21 @@ struct CommandLineStatus {
     for arg in mpvArguments {
       playerCore.mpv.setString(arg.0, arg.1)
     }
+  }
+}
+
+@available(OSX 10.13, *)
+class RemoteCommandController {
+  static let remoteCommand = MPRemoteCommandCenter.shared()
+
+  static var useSystemMediaControl: Bool = false
+
+  static func setup() {
+    remoteCommand.playCommand.addTarget(handler: PlayerCore.handlePlayCommand(_:))
+    remoteCommand.pauseCommand.addTarget(handler: PlayerCore.handlePauseCommand(_:))
+    remoteCommand.togglePlayPauseCommand.addTarget(handler: PlayerCore.handleTogglePlayPauseCommand(_:))
+    remoteCommand.stopCommand.addTarget(handler: PlayerCore.handleStopCommand(_:))
+    remoteCommand.nextTrackCommand.addTarget(handler: PlayerCore.handleNextTrackCommand(_:))
+    remoteCommand.previousTrackCommand.addTarget(handler: PlayerCore.handlePreviousTrackCommand(_:))
   }
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -144,7 +144,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if #available(macOS 10.13, *) {
       if RemoteCommandController.useSystemMediaControl {
         RemoteCommandController.setup()
-        NowPlayingInfoManager.updateState(.unknown)
+        NowPlayingInfoManager.updateState(.playing)
       }
     }
 

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "preference.scripts" = "Scripts";
 "preference.not_logged_in" = "Not logged in";
 "preference.logged_in_as" = "Logged in as %@";
+"preference.system_media_control" = "Use system media control";
 
 "menu.volume"= "Volume: %d";
 "menu.audio_delay" = "Audio Delay: %.2fs";

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -17,6 +17,7 @@
                 <outlet property="newConfigBtn" destination="Akd-0e-FKG" id="2CW-ho-HL1"/>
                 <outlet property="removeKmBtn" destination="uFG-OF-DJ5" id="XWN-Lt-tmc"/>
                 <outlet property="revealConfFileBtn" destination="KZA-hu-vhZ" id="lVg-3j-Qgp"/>
+                <outlet property="useMediaKeysButton" destination="LU9-QU-BFL" id="b9B-LC-pyM"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -152,7 +152,11 @@ class MPVController: NSObject {
 
     setUserOption(PK.screenshotTemplate, type: .string, forName: MPVOption.Screenshot.screenshotTemplate)
 
-    setUserOption(PK.useMediaKeys, type: .bool, forName: MPVOption.Input.inputMediaKeys)
+    if #available(macOS 10.13, *) {
+      chkErr(mpv_set_option_string(mpv, MPVOption.Input.inputMediaKeys, no_str))
+    } else {
+      setUserOption(PK.useMediaKeys, type: .bool, forName: MPVOption.Input.inputMediaKeys)
+    }
     setUserOption(PK.useAppleRemote, type: .bool, forName: MPVOption.Input.inputAppleremote)
 
     setUserOption(PK.keepOpenOnFileEnd, type: .other, forName: MPVOption.Window.keepOpen) { key in

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1463,8 +1463,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
   func updateTitle() {
     if player.info.isNetworkResource {
-      let mediaTitle = player.mpv.getString(MPVProperty.mediaTitle)
-      window?.title = mediaTitle ?? player.info.currentURL?.path ?? ""
+      window?.title = player.getMediaTitle()
     } else {
       window?.representedURL = player.info.currentURL
       window?.setTitleWithRepresentedFilename(player.info.currentURL?.path ?? "")

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -376,9 +376,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate {
   @objc
   func updateTrack() {
     DispatchQueue.main.async {
-      let mediaTitle = self.player.mpv.getString(MPVProperty.mediaTitle) ?? ""
-      let mediaArtist = self.player.mpv.getString("metadata/by-key/artist") ?? ""
-      let mediaAlbum = self.player.mpv.getString("metadata/by-key/album") ?? ""
+      let (mediaTitle, mediaArtist, mediaAlbum) = self.player.getMusicMetadata()
       self.titleLabel.stringValue = mediaTitle
       self.window?.title = mediaTitle
       // hide artist & album label when info not available

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -51,6 +51,9 @@ class PlaybackInfo {
   var isPaused: Bool = false {
     didSet {
       PlayerCore.checkStatusForSleep()
+      if #available(macOS 10.12.2, *) {
+        NowPlayingInfoManager.updateState(isPaused ? .paused : .playing)
+      }
     }
   }
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -51,8 +51,10 @@ class PlaybackInfo {
   var isPaused: Bool = false {
     didSet {
       PlayerCore.checkStatusForSleep()
-      if #available(macOS 10.12.2, *) {
-        NowPlayingInfoManager.updateState(isPaused ? .paused : .playing)
+      if #available(macOS 10.13, *) {
+        if RemoteCommandController.useSystemMediaControl {
+          NowPlayingInfoManager.updateState(isPaused ? .paused : .playing)
+        }
       }
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -88,44 +88,6 @@ class PlayerCore: NSObject {
     return useNew ? newPlayerCore : active
   }
 
-  // MARK: - Handle Remote Commands
-
-  @available(macOS 10.13, *)
-  static func handlePlayCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.togglePause(false)
-    return .success
-  }
-
-  @available(macOS 10.13, *)
-  static func handlePauseCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.togglePause(true)
-    return .success
-  }
-
-  @available(macOS 10.13, *)
-  static func handleTogglePlayPauseCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.togglePause(nil)
-    return .success
-  }
-
-  @available(macOS 10.13, *)
-  static func handleStopCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.stop()
-    return .success
-  }
-
-  @available(macOS 10.13, *)
-  static func handleNextTrackCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: true)
-    return .success
-  }
-
-  @available(macOS 10.13, *)
-  static func handlePreviousTrackCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
-    PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: false)
-    return .success
-  }
-
   // MARK: - Fields
 
   @available(macOS 10.12.2, *)
@@ -432,7 +394,7 @@ class PlayerCore: NSObject {
     case .relative:
       mpv.command(.seek, args: ["\(relativeSecond)", "relative"], checkError: false)
 
-    case .extract:
+    case .exact:
       mpv.command(.seek, args: ["\(relativeSecond)", "relative+exact"], checkError: false)
 
     case .auto:

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -23,6 +23,10 @@ class NowPlayingInfoManager {
     info.nowPlayingInfo = nowPlayingInfo
   }
 
+  static func updateState(_ state: MPNowPlayingPlaybackState) {
+    info.playbackState = state
+  }
+
 }
 
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -9,7 +9,7 @@
 import Cocoa
 import MediaPlayer
 
-@available (macOS 10.12.2, *)
+@available (macOS 10.13, *)
 class NowPlayingInfoManager {
   static let info = MPNowPlayingInfoCenter.default()
 
@@ -90,37 +90,37 @@ class PlayerCore: NSObject {
 
   // MARK: - Handle Remote Commands
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handlePlayCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.togglePause(false)
     return .success
   }
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handlePauseCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.togglePause(true)
     return .success
   }
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handleTogglePlayPauseCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.togglePause(nil)
     return .success
   }
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handleStopCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.stop()
     return .success
   }
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handleNextTrackCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: true)
     return .success
   }
 
-  @available(macOS 10.12.2, *)
+  @available(macOS 10.13, *)
   static func handlePreviousTrackCommand(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
     PlayerCore.lastActive.navigateInPlaylist(nextOrPrev: false)
     return .success
@@ -1047,8 +1047,10 @@ class PlayerCore: NSObject {
   }
 
   @objc func syncUITime() {
-    if #available(macOS 10.12.2, *) {
-      NowPlayingInfoManager.updateInfo()
+    if #available(macOS 10.13, *) {
+      if RemoteCommandController.useSystemMediaControl {
+        NowPlayingInfoManager.updateInfo()
+      }
     }
     if info.isNetworkResource {
       syncUI(.timeAndCache)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -15,6 +15,18 @@ class NowPlayingInfoManager {
 
   static func updateInfo() {
     var nowPlayingInfo = [String: Any]()
+    let activePlayer = PlayerCore.lastActive
+
+    let isAudio = activePlayer.currentMediaIsAudio == .isAudio
+    nowPlayingInfo[MPMediaItemPropertyMediaType] = isAudio ? MPNowPlayingInfoMediaType.audio : MPNowPlayingInfoMediaType.video
+    let (title, album, artist) = activePlayer.getMusicMetadata()
+    nowPlayingInfo[MPMediaItemPropertyTitle] = title
+    if isAudio {
+      nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = album
+      nowPlayingInfo[MPMediaItemPropertyArtist] = artist
+    }
+
+
     let duration = PlayerCore.lastActive.info.videoDuration?.second ?? 0
     nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = duration
     nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = PlayerCore.lastActive.info.videoPosition?.second ?? 0
@@ -1228,6 +1240,13 @@ class PlayerCore: NSObject {
                                index:     index)
       info.chapters.append(chapter)
     }
+  }
+
+  func getMusicMetadata() -> (title: String, album: String, artist: String) {
+    let title = mpv.getString(MPVProperty.mediaTitle) ?? ""
+    let album = mpv.getString("metadata/by-key/album") ?? ""
+    let artist = mpv.getString("metadata/by-key/artist") ?? ""
+    return (title, album, artist)
   }
 
   // MARK: - Utils

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -55,7 +55,7 @@ class PrefKeyBindingViewController: NSViewController, MASPreferencesViewControll
   @IBOutlet weak var deleteConfFileBtn: NSButton!
   @IBOutlet weak var newConfigBtn: NSButton!
   @IBOutlet weak var duplicateConfigBtn: NSButton!
-
+  @IBOutlet weak var useMediaKeysButton: NSButton!
 
 
   override func viewDidLoad() {
@@ -65,6 +65,10 @@ class PrefKeyBindingViewController: NSViewController, MASPreferencesViewControll
     kbTableView.dataSource = self
     kbTableView.delegate = self
     kbTableView.doubleAction = #selector(editRow)
+
+    if #available(macOS 10.13, *) {
+      useMediaKeysButton.title = "Use system media control"
+    }
 
     // config files
     // - default

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -67,7 +67,7 @@ class PrefKeyBindingViewController: NSViewController, MASPreferencesViewControll
     kbTableView.doubleAction = #selector(editRow)
 
     if #available(macOS 10.13, *) {
-      useMediaKeysButton.title = "Use system media control"
+      useMediaKeysButton.title = NSLocalizedString("preference.system_media_control", comment: "Use system media control")
     }
 
     // config files

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -292,7 +292,7 @@ struct Preference {
 
   enum SeekOption: Int, InitializingFromKey {
     case relative = 0
-    case extract
+    case exact
     case auto
 
     static var defaultValue = SeekOption.relative

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "preference.scripts" = "脚本";
 "preference.not_logged_in" = "未登录";
 "preference.logged_in_as" = "已登录 %@";
+"preference.system_media_control" = "使用系统媒体控制";
 
 "menu.volume"= "音量: %d";
 "menu.audio_delay" = "音频延迟: %.2f秒";


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #451, #477, #846, #778, #799, #791. (macOS 10.13+ only)

---

**Description:**

This pull request integrates MediaPlayer framework and enables multiple system media controls. 

Even though the document says MediaPlayer framework is available on macOS 10.12.1+, based on by test, it only works on 10.13. So that I kept macOS 10.13- using the legacy mpv media key functionality and enables MediaPlayer framework on macOS 10.13+. The label `Use media keys` in Preferences > Keybindings will be displayed as `Use system media control` in macOS 10.13+.

It is supposed to
- make IINA stay in the touch bar "media center" system (#451)
- not capture keys(by mpv) anymore (i.e. the caps lock key) (#477, #846, #778)
- make IINA to be controlled by system (i.e. bluetooth devices, AirPods, media keys) (#799, #791)
- shows IINA in the "Now Playing" widget