### PR TITLE
Fix a typo in italian localization

### DIFF
--- a/iina/it.lproj/PrefGeneralViewController.strings
+++ b/iina/it.lproj/PrefGeneralViewController.strings
@@ -77,7 +77,7 @@
 /* Class = "NSTextFieldCell"; title = "Behavior:"; ObjectID = "uQR-Fx-oEm"; */
 "uQR-Fx-oEm.title" = "Comportamento:";
 
-"6TV-DG-503.title" = "Palylist:";
+"6TV-DG-503.title" = "Playlist:";
 
 "QJq-fO-hhK.title" = "Aggiungi automaticamente i file presenti nella stessa cartella";
 


### PR DESCRIPTION
**Description:**
`Palylist:` should be `Playlist:`