### PR TITLE
mini player: add touch bar support for music

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		84FBCB381EEACDDD0076C77C /* FFmpegController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FBCB371EEACDDD0076C77C /* FFmpegController.m */; };
 		84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBF23D1EF06A90003EA491 /* ThumbnailCache.swift */; };
 		9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */; };
+		B72199F31F9A755800E2E774 /* MiniPlayerWindowTouchBarSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72199F21F9A755800E2E774 /* MiniPlayerWindowTouchBarSupport.swift */; };
 		C75540751E7886FE00C13D4A /* SubSelectWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C75540771E7886FE00C13D4A /* SubSelectWindowController.xib */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
 /* End PBXBuildFile section */
@@ -827,6 +828,7 @@
 		B3B24B621E831068008393CE /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/SubSelectWindowController.strings; sourceTree = "<group>"; };
 		B3D578841EBCE6B200757AAA /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B3DB9C081E82CE2B00CFB888 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = it; path = it.lproj/Contribution.rtf; sourceTree = "<group>"; };
+		B72199F21F9A755800E2E774 /* MiniPlayerWindowTouchBarSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindowTouchBarSupport.swift; sourceTree = "<group>"; };
 		C70BC05C1E511D1000D8CB79 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/KeyBinding.strings; sourceTree = "<group>"; };
 		C7513B4A1F61C05D00C14561 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/FilterPresets.strings; sourceTree = "<group>"; };
 		C7513B4C1F61C5A300C14561 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/FreeSelectingViewController.strings; sourceTree = "<group>"; };
@@ -1082,6 +1084,7 @@
 				849581EF1F02728700D3B359 /* InitialWindowController.swift */,
 				849581F51F03D55A00D3B359 /* InitialWindowController.xib */,
 				84A09A0C1F2DF596000FF343 /* MiniPlayerWindowController.swift */,
+				B72199F21F9A755800E2E774 /* MiniPlayerWindowTouchBarSupport.swift */,
 				84A09A0D1F2DF596000FF343 /* MiniPlayerWindowController.xib */,
 				84D0FB7B1F5E510C00C6A6A7 /* Interactive Mode */,
 				84D377691D74163B007F7396 /* Video */,
@@ -1726,6 +1729,7 @@
 				84AE59491E0FD65800771B7E /* MainMenuActions.swift in Sources */,
 				84F725561D4783EE000DEF1B /* VolumeSliderCell.swift in Sources */,
 				845040401E0ACADD0079C194 /* MPVNode.swift in Sources */,
+				B72199F31F9A755800E2E774 /* MiniPlayerWindowTouchBarSupport.swift in Sources */,
 				84795C3A1E083EE30059A648 /* PrefControlViewController.swift in Sources */,
 				8488D6DF1E11791300D5B952 /* PrefCodecViewController.swift in Sources */,
 				8487BEC11D744FA800FD17B0 /* FlippedView.swift in Sources */,

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -219,3 +219,5 @@
 "touchbar.play_pause" = "Play / Pause";
 "touchbar.seek" = "Seek";
 "touchbar.time" = "Time Position";
+"touchbar.next_track" = "Next Track";
+"touchbar.prev_track" = "Previous Track";

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -37,6 +37,10 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate {
   @IBOutlet weak var playSlider: NSSlider!
   @IBOutlet weak var volumeSlider: NSSlider!
   @IBOutlet weak var volumeLabel: NSTextField!
+  
+  // touch bar views
+  weak var touchBarPlayPauseBtn: NSButton?
+  weak var touchBarCurrentPosLabel: DurationDisplayTextField?
 
   var isOntop = false
   var isPlaylistVisible = false
@@ -164,6 +168,10 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate {
     let percentage = (pos.second / duration.second) * 100
     leftLabel.stringValue = pos.stringRepresentation
     rightLabel.updateText(with: duration, given: pos)
+    
+    // update touch bar label
+    touchBarCurrentPosLabel?.updateText(with: duration, given: pos)
+    
     if andProgressBar {
       playSlider.doubleValue = percentage
     }

--- a/iina/MiniPlayerWindowTouchBarSupport.swift
+++ b/iina/MiniPlayerWindowTouchBarSupport.swift
@@ -1,0 +1,120 @@
+//
+//  MiniPlayerWindowTouchBarSupport.swift
+//  iina
+//
+//  Created by @doukasd on 20/10/2017.
+//  Copyright © 2017 lhc. All rights reserved.
+//
+
+import Cocoa
+
+// MARK: TouchBar Support
+
+@available(OSX 10.12.2, *)
+fileprivate extension NSTouchBar.CustomizationIdentifier {
+  static let miniPlayerBar = NSTouchBar.CustomizationIdentifier("\(Bundle.main.bundleIdentifier!).miniPlayerTouchBar")
+}
+
+@available(OSX 10.12.2, *)
+fileprivate extension NSTouchBarItem.Identifier {
+  static let playPause = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.playPause")
+  static let volumeUp = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.voUp")
+  static let volumeDown = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.voDn")
+  static let time = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.time")
+  static let next = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.next")
+  static let prev = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.prev")
+}
+
+// Image name, tag, custom label
+@available(macOS 10.12.2, *)
+fileprivate let touchBarItemBinding: [NSTouchBarItem.Identifier: (NSImage.Name, Int, String)] = [
+  .next: (.touchBarSkipAheadTemplate, 0, NSLocalizedString("touchbar.next_track", comment: "Next Track")),
+  .prev: (.touchBarSkipBackTemplate, 1, NSLocalizedString("touchbar.prev_track", comment: "Previous Track")),
+  .volumeUp: (.touchBarVolumeUpTemplate, 0, NSLocalizedString("touchbar.increase_volume", comment: "Volume +")),
+  .volumeDown: (.touchBarVolumeDownTemplate, 1, NSLocalizedString("touchbar.decrease_volume", comment: "Volume -")),
+]
+
+@available(macOS 10.12.2, *)
+extension MiniPlayerWindowController: NSTouchBarDelegate {
+  
+  override func makeTouchBar() -> NSTouchBar? {
+    let touchBar = NSTouchBar()
+    touchBar.delegate = self
+    touchBar.customizationIdentifier = .miniPlayerBar
+    touchBar.defaultItemIdentifiers = [.flexibleSpace, .time, .playPause, .prev, .next, .flexibleSpace]
+    touchBar.customizationAllowedItemIdentifiers = [.playPause, .volumeUp, .volumeDown, .time, .next, .prev, .fixedSpaceLarge, .flexibleSpace]
+    return touchBar
+  }
+  
+  func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
+    
+    switch identifier {
+      
+    case .playPause:
+      let item = NSCustomTouchBarItem(identifier: identifier)
+      item.view = NSButton(image: NSImage(named: .touchBarPauseTemplate)!, target: self, action: #selector(self.touchBarPlayBtnAction(_:)))
+      item.customizationLabel = NSLocalizedString("touchbar.play_pause", comment: "Play / Pause")
+      self.touchBarPlayPauseBtn = item.view as? NSButton
+      return item
+      
+    case .volumeUp,
+         .volumeDown:
+      guard let data = touchBarItemBinding[identifier] else { return nil }
+      return buttonTouchBarItem(withIdentifier: identifier, imageName: data.0, tag: data.1, customLabel: data.2, action: #selector(self.touchBarVolumeAction(_:)))
+      
+    case .time:
+      let item = NSCustomTouchBarItem(identifier: identifier)
+      let label = DurationDisplayTextField(labelWithString: "00:00")
+      label.alignment = .center
+      label.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .current
+      self.touchBarCurrentPosLabel = label
+      item.view = label
+      item.customizationLabel = NSLocalizedString("touchbar.time", comment: "Time Position")
+      return item
+      
+    case .next,
+         .prev:
+      guard let data = touchBarItemBinding[identifier] else { return nil }
+      return buttonTouchBarItem(withIdentifier: identifier, imageName: data.0, tag: data.1, customLabel: data.2, action: #selector(self.touchBarSkipAction(_:)))
+      
+    default:
+      return nil
+    }
+  }
+  
+  // update the play/pause button image
+  func updateTouchBarPlayBtn() {
+    if player.info.isPaused {
+      touchBarPlayPauseBtn?.image = NSImage(named: .touchBarPauseTemplate)
+    } else {
+      touchBarPlayPauseBtn?.image = NSImage(named: .touchBarPlayTemplate)
+    }
+  }
+  
+  // action for Pause/Play button
+  @objc func touchBarPlayBtnAction(_ sender: NSButton) {
+    player.togglePause(nil)
+    updateTouchBarPlayBtn()
+  }
+  
+  // action for Volume Up/Down buttons
+  @objc func touchBarVolumeAction(_ sender: NSButton) {
+    let currVolume = player.info.volume
+    player.setVolume(currVolume + (sender.tag == 0 ? 5 : -5))
+  }
+  
+  // action for Next/Prev Track buttons
+  @objc func touchBarSkipAction(_ sender: NSButton) {
+    player.navigateInPlaylist(nextOrPrev: sender.tag == 0)
+  }
+  
+  private func buttonTouchBarItem(withIdentifier identifier: NSTouchBarItem.Identifier, imageName: NSImage.Name, tag: Int, customLabel: String, action: Selector) -> NSCustomTouchBarItem {
+    let item = NSCustomTouchBarItem(identifier: identifier)
+    let button = NSButton(image: NSImage(named: imageName)!, target: self, action: action)
+    button.tag = tag
+    item.view = button
+    item.customizationLabel = customLabel
+    return item
+  }
+  
+}


### PR DESCRIPTION
Hey @lhc70000,

First of all thanks for IINA, I've only been using it for a few days and love it. I just started using it for music and realised that the recent Mini Player did not have touch bar support yet, so I added it.

1. Sorry for not opening an issue first, I did this feature for myself but thought I'd share afterwards.
2. The addition is very simple and self contained. The whole logic is copied from the Main Window touch bar support so all styles and design is the same.
3. We can probably share some logic for touch bar support between the 2 classes but Swift is not my main language so I started the simple way.

Cheers,
Dimitris