### PR TITLE
Add .gitattributes to prevent `git diff` on auto-generated text files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.pbxproj binary
+*.xib binary
+*.rtf binary
+*.plist binary
+*.xcscheme binary
+Podfile.lock binary


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

Adding .gitattributes will give us a much clearer output on `git diff`.