### PR TITLE
Thumbnail cache

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1113,7 +1113,7 @@ class PlayerCore: NSObject {
     info.thumbnailsProgress = 0
     info.thumbnailsReady = false
     if Preference.bool(for: .enableThumbnailPreview) {
-      if let cacheName = info.mpvMd5, ThumbnailCache.fileExists(forName: cacheName) {
+      if let cacheName = info.mpvMd5, ThumbnailCache.fileIsCached(forName: cacheName, forVideo: info.currentURL) {
         thumbnailQueue.async {
           if let thumbnails = ThumbnailCache.read(forName: cacheName) {
             self.info.thumbnails = thumbnails
@@ -1360,7 +1360,7 @@ extension PlayerCore: FFmpegControllerDelegate {
       refreshTouchBarSlider()
       if let cacheName = info.mpvMd5 {
         backgroundQueue.async {
-          ThumbnailCache.write(self.info.thumbnails, forName: cacheName)
+          ThumbnailCache.write(self.info.thumbnails, forName: cacheName, forVideo: self.info.currentURL)
         }
       }
     }

--- a/iina/ThumbnailCache.swift
+++ b/iina/ThumbnailCache.swift
@@ -9,10 +9,16 @@
 import Cocoa
 
 class ThumbnailCache {
+  static private var version = 2
 
   static private let sizeofDouble = MemoryLayout<Double>.size
   static private let sizeofInt64 = MemoryLayout<Int64>.size
+  static private let sizeofUInt64 = MemoryLayout<UInt64>.size
+  static private let sizeofUInt8 = MemoryLayout<UInt8>.size
+  
+  static private let sizeofMetadata = sizeofInt64 + sizeofUInt64 + sizeofInt64
 
+  
   static private let imageProperties: [NSBitmapImageRep.PropertyKey: Any] = [
     .compressionFactor: 0.75
   ]
@@ -20,10 +26,46 @@ class ThumbnailCache {
   static func fileExists(forName name: String) -> Bool {
     return FileManager.default.fileExists(atPath: urlFor(name).path)
   }
+  
+  static func fileIsCached(forName name: String, forVideo videoPath: URL?) -> Bool {
+    guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
+      Utility.log("Cannot get video file attributes")
+      return false
+    }
+    
+    // file size
+    guard let fileSize = fileAttr[.size] as? UInt64 else {
+      Utility.log("Cannot get video file size")
+      return false
+    }
+    
+    // modified date
+    guard let fileModifiedDate = fileAttr[.modificationDate] as? Date else {
+      Utility.log("Cannot get video file modification date")
+      return false
+    }
+    let fileTimestamp = Int64(fileModifiedDate.timeIntervalSince1970)
+    
+    // Check metadate in the cache
+    if self.fileExists(forName: name) {
+      guard let file = try? FileHandle(forReadingFrom: urlFor(name)) else {
+        Utility.log("Cannot open cache file.")
+        return false
+      }
+      
+      let cacheVersion: Int = file.readData(ofLength: sizeofUInt8).withUnsafeBytes { $0.pointee }
+      if cacheVersion != version { return false }
+      
+      return file.readData(ofLength: sizeofUInt64).withUnsafeBytes { $0.pointee } == fileSize &&
+             file.readData(ofLength: sizeofInt64).withUnsafeBytes { $0.pointee } == fileTimestamp
+    }
+    
+    return false
+  }
 
   /// Write thumbnail cache to file. 
   /// This method is expected to be called when the file doesn't exist.
-  static func write(_ thumbnails: [FFThumbnail], forName name: String) {
+  static func write(_ thumbnails: [FFThumbnail], forName name: String, forVideo videoPath: URL?) {
     // Utility.log("Writing thumbnail cache...")
 
     let maxCacheSize = Preference.integer(for: .maxThumbnailPreviewCacheSize) * FileSize.Unit.mb.rawValue
@@ -44,9 +86,30 @@ class ThumbnailCache {
     }
 
     // version
-    var version = Int64(1)
-    let versionData = Data(bytes: &version, count: sizeofInt64)
+    let versionData = Data(bytes: &version, count: sizeofUInt8)
     file.write(versionData)
+    
+    guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
+      Utility.log("Cannot get video file attributes")
+      return
+    }
+    
+    // file size
+    guard var fileSize = fileAttr[.size] as? UInt64 else {
+      Utility.log("Cannot get video file size")
+      return
+    }
+    let fileSizeData = Data(bytes: &fileSize, count: sizeofUInt64)
+    file.write(fileSizeData)
+    
+    // modified date
+    guard let fileModifiedDate = fileAttr[.modificationDate] as? Date else {
+      Utility.log("Cannot get video file modification date")
+      return
+    }
+    var fileTimestamp = Int64(fileModifiedDate.timeIntervalSince1970)
+    let fileModificationDateData = Data(bytes: &fileTimestamp, count: sizeofInt64)
+    file.write(fileModificationDateData)
 
     // data blocks
     for tb in thumbnails {
@@ -86,10 +149,9 @@ class ThumbnailCache {
     // get file length
     file.seekToEndOfFile()
     let eof = file.offsetInFile
-    file.seek(toFileOffset: 0)
 
-    // version
-    let _ = file.readData(ofLength: sizeofInt64)
+    // skip metadata
+    file.seek(toFileOffset: UInt64(sizeofMetadata))
 
     // data blocks
     while file.offsetInFile != eof {


### PR DESCRIPTION
- [X] This change has been discussed with the author.
- [X] It implements / fixes issue #1058 .

---

**Description:**

Write video file's size and modified date to cache file. Check those properties to determine the video file remains the same.