### PR TITLE
Add “Open Link in IINA” context menu item to Safari extension

### DIFF
--- a/browser/Open_In_IINA.safariextension/Info.plist
+++ b/browser/Open_In_IINA.safariextension/Info.plist
@@ -28,6 +28,14 @@
 				<key>Title</key>
 				<string>Open Current Page in IINA</string>
 			</dict>
+			<dict>
+				<key>Command</key>
+				<string>open_link_in_iina_menu_cmd</string>
+				<key>Identifier</key>
+				<string>open_link_in_iina</string>
+				<key>Title</key>
+				<string>Open Link in IINA</string>
+			</dict>
 		</array>
 		<key>Global Page</key>
 		<string>global.html</string>
@@ -48,6 +56,16 @@
 				<string>Open current webpage in IINA</string>
 			</dict>
 		</array>
+	</dict>
+	<key>Content</key>
+	<dict>
+		<key>Scripts</key>
+		<dict>
+			<key>Start</key>
+			<array>
+				<string>injected.js</string>
+			</array>
+		</dict>
 	</dict>
 	<key>Description</key>
 	<string>Open current webpage in IINA</string>

--- a/browser/Open_In_IINA.safariextension/global.js
+++ b/browser/Open_In_IINA.safariextension/global.js
@@ -1,17 +1,36 @@
-const command_menu = "open_in_iina_menu_cmd"
-const command_btn = "open_in_iina_toolbar_btn_cmd" 
+const command_menu = "open_in_iina_menu_cmd";
+const command_btn = "open_in_iina_toolbar_btn_cmd";
+const command_link_menu = "open_link_in_iina_menu_cmd";
 
 var eventHandler = function(event) {
-  if (event.command == command_menu || event.command == command_btn) {
-    var tab = safari.application.activeBrowserWindow.activeTab
-    var active_url = tab.url
-    if (active_url) {
-      var url = "iina://weblink?url=" + encodeURIComponent(active_url)
-      tab.url = url
-    } else {
-      window.alert("Cannot get current URL!")
+    var tab = safari.application.activeBrowserWindow.activeTab;
+    var url = "iina://weblink?url=";
+
+    if (event.command == command_menu || event.command == command_btn) {
+        var active_url = tab.url;
+        if (active_url) {
+            url += encodeURIComponent(active_url);
+            tab.url = url;
+        } else {
+            window.alert("Cannot get current URL!");
+        }
+    } else if (event.command === command_link_menu) {
+        var link = event.userInfo;
+        if (link) {
+            url += encodeURIComponent(link);
+            tab.url = url;
+        } else {
+            window.alert("Unable to find URL.");
+        }
     }
-  }
+};
+
+function validateItem(event) {
+    if (event.command === command_link_menu) {
+        var linkFound = typeof(event.userInfo) === 'undefined';
+        event.target.disabled = linkFound;
+    }
 }
 
-safari.application.addEventListener("command", eventHandler, false)
+safari.application.addEventListener("command", eventHandler, false);
+safari.application.addEventListener("validate", validateItem, false);

--- a/browser/Open_In_IINA.safariextension/injected.js
+++ b/browser/Open_In_IINA.safariextension/injected.js
@@ -1,0 +1,9 @@
+function handleContextMenu(event) {
+    var target = event.target;
+    while (target != null && target.nodeType == Node.ELEMENT_NODE && target.nodeName.toLowerCase() != "a") {
+        target = target.parentNode;
+    }
+    safari.self.tab.setContextMenuEventUserInfo(event, target.href);
+}
+
+document.addEventListener("contextmenu", handleContextMenu, false);


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
This PR adds an “Open Link in IINA” item to context menus in Safari. It’s context-aware, so the item will only appear when the user is right-clicking on a link. This is useful because it allows the user to open linked content in IINA directly without having load the page first or copy the URL and paste it in IINA.