### PR TITLE
Display both current time and remaining time on TouchBar simultaneously

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -340,9 +340,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     case PK.showRemainingTime.rawValue:
       if let newValue = change[.newKey] as? Bool {
         rightLabel.mode = newValue ? .remaining : .duration
-        if #available(OSX 10.12.2, *) {
-          player.touchBarSupport.touchBarCurrentPosLabel?.mode = newValue ? .remaining : .current
-        }
       }
 
     case PK.blackOutMonitor.rawValue:
@@ -2261,6 +2258,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     leftLabel.stringValue = pos.stringRepresentation
     if #available(OSX 10.12.2, *) {
       player.touchBarSupport.touchBarCurrentPosLabel?.updateText(with: duration, given: pos)
+      player.touchBarSupport.touchBarRemainingPosLabel?.updateText(with: duration, given: pos)
     }
     rightLabel.updateText(with: duration, given: pos)
     if andProgressBar {

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -27,6 +27,7 @@ fileprivate extension NSTouchBarItem.Identifier {
   static let rewind = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.rewind")
   static let fastForward = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.forward")
   static let time = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.time")
+  static let remainingTime = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.remainingTime")
   static let ahead15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead15Sec")
   static let back15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.back15Sec")
   static let ahead30Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead30Sec")
@@ -60,14 +61,15 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
     let touchBar = NSTouchBar()
     touchBar.delegate = self
     touchBar.customizationIdentifier = .windowBar
-    touchBar.defaultItemIdentifiers = [.playPause, .slider, .time]
-    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .fixedSpaceLarge]
+    touchBar.defaultItemIdentifiers = [.playPause, .time, .slider, .remainingTime]
+    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .remainingTime, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .fixedSpaceLarge]
     return touchBar
   }()
 
   weak var touchBarPlaySlider: TouchBarPlaySlider?
   weak var touchBarPlayPauseBtn: NSButton?
   weak var touchBarCurrentPosLabel: DurationDisplayTextField?
+  weak var touchBarRemainingPosLabel: DurationDisplayTextField?
   var touchBarPosLabelWidthLayout: NSLayoutConstraint?
   /** The current/remaining time label in Touch Bar. */
   lazy var sizingTouchBarTextField: NSTextField = {
@@ -115,10 +117,20 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       let item = NSCustomTouchBarItem(identifier: identifier)
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
-      label.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .current
+      label.mode = .current
       self.touchBarCurrentPosLabel = label
       item.view = label
       item.customizationLabel = NSLocalizedString("touchbar.time", comment: "Time Position")
+      return item
+    
+    case .remainingTime:
+      let item = NSCustomTouchBarItem(identifier: identifier)
+      let label = DurationDisplayTextField(labelWithString: "00:00")
+      label.alignment = .center
+      label.mode = .remaining
+      self.touchBarRemainingPosLabel = label
+      item.view = label
+      item.customizationLabel = NSLocalizedString("touchbar.remainingTime", comment: "Remaining Time Position")
       return item
 
     case .ahead15Sec,
@@ -186,14 +198,22 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
     let duration: VideoTime = player.info.videoDuration ?? .zero
     let pad: CGFloat = 16.0
     sizingTouchBarTextField.stringValue = duration.stringRepresentation
-    if let widthConstant = sizingTouchBarTextField.cell?.cellSize.width, let posLabel = touchBarCurrentPosLabel {
+    if let widthConstant = sizingTouchBarTextField.cell?.cellSize.width, touchBarCurrentPosLabel != nil || touchBarRemainingPosLabel != nil {
       if let posConstraint = touchBarPosLabelWidthLayout {
         posConstraint.constant = widthConstant + pad
-        posLabel.setNeedsDisplay()
+        touchBarCurrentPosLabel?.setNeedsDisplay()
+        touchBarRemainingPosLabel?.setNeedsDisplay()
       } else {
-        let posConstraint = NSLayoutConstraint(item: posLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: widthConstant + pad)
-        posLabel.addConstraint(posConstraint)
-        touchBarPosLabelWidthLayout = posConstraint
+        if let posLabel = touchBarCurrentPosLabel {
+          let posConstraint = NSLayoutConstraint(item: posLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: widthConstant + pad)
+          posLabel.addConstraint(posConstraint)
+          touchBarPosLabelWidthLayout = posConstraint
+        }
+        if let posLabel = touchBarRemainingPosLabel {
+          let posConstraint = NSLayoutConstraint(item: posLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.0, constant: widthConstant + pad)
+          posLabel.addConstraint(posConstraint)
+          touchBarPosLabelWidthLayout = posConstraint
+        }
       }
     }
 

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -186,4 +186,5 @@
 "touchbar.rewind" = "快退";
 "touchbar.seek" = "進度條";
 "touchbar.time" = "播放進度";
+"touchbar.remainingTime" = "剩餘時間";
 "track.none" = "<無>";


### PR DESCRIPTION

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

Currently there is a toggle that switch between current time and remaining time to be displayed on TouchBar. This situation is not quite consistent with other players like QuickTimePlayer which can display both at the same time. Besides, a toggle deep in the preference panel is quite intuitive ti find when you want to change the TouchBar functionality.

I added split the current time TouchBar item from the remaining time one, so that it is now possible to display both current time and remaining time on TouchBar simultaneously. And this is done in the TouchBar customization panel. 

The toggle in preference still controls whether the right time label of the control bar displays total duration or the remaining time. This functionality is not tweaked.

Really wish that you consider this change.
