### PR TITLE
Change the esc button to exit-full-screen icon on the TouchBar.

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1264,6 +1264,10 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       player.togglePause(false)
     }
 
+    if #available(macOS 10.12.2, *) {
+      player.touchBarSupport.toggleTouchBarEsc(enteringFullScr: true)
+    }
+    
     updateWindowParametersForMPV()
   }
 
@@ -1318,6 +1322,10 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && !player.info.isPaused {
       player.togglePause(true)
+    }
+
+    if #available(macOS 10.12.2, *) {
+      player.touchBarSupport.toggleTouchBarEsc(enteringFullScr: false)
     }
 
     // restore ontop status


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
This is purely an appearance change to make it consistent among the platform. When esc button is bound to exit full screen, the TouchBar ESC button should reflect it.