### PR TITLE
Fix: Use macOS Standard Logs Directory

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -39,7 +39,6 @@ struct AppData {
   static let encodings = CharEncoding.list
 
   static let userInputConfFolder = "input_conf"
-  static let logFolder = "log"
   static let watchLaterFolder = "watch_later"
   static let historyFile = "history.plist"
   static let thumbnailCacheFolder = "thumb_cache"

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -395,9 +395,14 @@ class Utility {
   }()
 
   static let logDirURL: URL = {
-    let url = Utility.appSupportDirUrl.appendingPathComponent(AppData.logFolder, isDirectory: true)
-    createDirIfNotExist(url: url)
-    return url
+    // get path
+    let libraryPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+    Utility.assert(libraryPath.count >= 1, "Cannot get path to Logs directory")
+    let logsUrl = libraryPath.first!.appendingPathComponent("Logs", isDirectory: true)
+    let bundleID = Bundle.main.bundleIdentifier!
+    let appLogsUrl = logsUrl.appendingPathComponent(bundleID, isDirectory: true)
+    createDirIfNotExist(url: appLogsUrl)
+    return appLogsUrl
   }()
 
   static let watchLaterURL: URL = {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---
<img width="994" alt="screen shot 2018-02-12 at 19 52 20" src="https://user-images.githubusercontent.com/1630917/36113803-53e889da-102e-11e8-8615-f21c7231fad3.PNG">
---

⚠️**Problem**
Currently, logs are placed in: <ins>**~/Application Support/com.colliderli.iina/logs**</ins>
This is makes it impractical to impossible to use macOS' log viewer – `Console.app` – to view IINAs logs, and constitutes non-standard behaviour.

✅**Solution**
This PR moves the logs to: <ins>**~/Library/Logs/com.colliderli.iina/**</ins>
This allows using `Console.app` for viewing IINAs logs live and is [compliant with macOS standards](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html).