### PR TITLE
Use .fileSystemRepresentation when getting file paths from NSStrings.

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -88,7 +88,7 @@ return -1;\
 {
   int i, ret;
 
-  char *cFilename = strdup(file.UTF8String);
+  char *cFilename = strdup(file.fileSystemRepresentation);
   [_thumbnails removeAllObjects];
   [_thumbnailPartialResult removeAllObjects];
   [_addedTimestamps removeAllObjects];


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
`-[NSString fileSystemRepresentation]` better handles strange characters and is the recommended way of sending file paths to lower-level file APIs.