### PR TITLE
Added a script to check Localizable.strings when building

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -1627,6 +1627,7 @@
 			buildConfigurationList = 84EB1EF91D2F51D3004FA5A1 /* Build configuration list for PBXNativeTarget "iina" */;
 			buildPhases = (
 				36C8205F8EFBC756D3D0BD69 /* [CP] Check Pods Manifest.lock */,
+				E364D521203F339A0066215D /* Check Localizable.strings */,
 				84EB1ED21D2F51D3004FA5A1 /* Sources */,
 				84EB1ED31D2F51D3004FA5A1 /* Frameworks */,
 				84EB1ED41D2F51D3004FA5A1 /* Resources */,
@@ -1845,6 +1846,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iina/Pods-iina-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E364D521203F339A0066215D /* Check Localizable.strings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Localizable.strings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = $PROJECT_DIR/other/check_localizable.swift;
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -190,3 +190,12 @@ Programmet afsluttes.";
 "touchbar.seek" = "Spol";
 "touchbar.time" = "Tids Position";
 "track.none" = "<None>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -192,3 +192,12 @@ Beispiel: 20:35";
 "touchbar.seek" = "Verlauf";
 "touchbar.time" = "Position";
 "track.none" = "<Leer>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -187,3 +187,12 @@
 "touchbar.seek" = "Buscar";
 "touchbar.time" = "Posición en el tiempo";
 "track.none" = "<Ninguno>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -191,3 +191,12 @@ Vous aurez peut-être à répéter l'opération précédente (par exemple, activ
 "touchbar.seek" = "Chercher";
 "touchbar.time" = "Position horaire";
 "track.none" = "<Aucun>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -191,3 +191,12 @@ Potresti dover ripetere le operazioni precedenti (ad es. reimpostare il ritaglio
 "touchbar.seek" = "Ricerca";
 "touchbar.time" = "Time Position";
 "track.none" = "<Nessuno>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -191,3 +191,12 @@
 "touchbar.seek" = "シーク";
 "touchbar.time" = "再生位置";
 "track.none" = "<なし>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -221,3 +221,57 @@
 "alert.nothing_to_open" = "Niets om te openen.";
 "alert.no_video_track" = "Er is geen video spoor.";
 "subencoding.auto" = "Automatisch detecteren.";
+
+/* FIXME: Using English localization instead */
+"menu.speed_down" = "Speed Down to %.1fx";
+
+/* FIXME: Using English localization instead */
+"menu.audio_delay_up" = "Audio Delay + %.1fs";
+
+/* FIXME: Using English localization instead */
+"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+
+/* FIXME: Using English localization instead */
+"menu.speed" = "Speed: %.2fx";
+
+/* FIXME: Using English localization instead */
+"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
+
+/* FIXME: Using English localization instead */
+"menu.volume_up" = "Volume + %.0f%%";
+
+/* FIXME: Using English localization instead */
+"osd.filter_added" = "Added Filter: %@";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"menu.seek_backward" = "Step Backward %.0fs";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"menu.seek_forward" = "Step Forward %.0fs";
+
+/* FIXME: Using English localization instead */
+"menu.volume_down" = "Volume - %.0f%%";
+
+/* FIXME: Using English localization instead */
+"alert.duplicate_config" = "You cannot edit default configurations directly. Please duplicate it before editing.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";
+
+/* FIXME: Using English localization instead */
+"menu.speed_up" = "Speed Up to %.1fx";
+
+/* FIXME: Using English localization instead */
+"preference.system_media_control" = "Use system media control";
+
+/* FIXME: Using English localization instead */
+"osd.filter_removed" = "Removed Filter";
+
+/* FIXME: Using English localization instead */
+"menu.audio_delay_down" = "Audio Delay - %.1fs";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -190,3 +190,12 @@
 "touchbar.seek" = "Szukaj";
 "touchbar.time" = "Pozycja czasowa";
 "track.none" = "Brak ścieżki";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -238,3 +238,12 @@
 "touchbar.play_pause" = "Tocar / Pausar";
 "touchbar.seek" = "Buscar";
 "touchbar.time" = "Posição do Tempo";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -191,3 +191,12 @@
 "touchbar.seek" = "Перемотка";
 "touchbar.time" = "Временная позиция";
 "track.none" = "<Нет>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -191,3 +191,12 @@ Môžete zopakovať predchádzajúcu úpravu (napr. orezanie), aby všetko fungo
 "touchbar.seek" = "Vyhľadať";
 "touchbar.time" = "Pozícia";
 "track.none" = "<Prázdne>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -190,3 +190,12 @@ Uygulamadan şimdi çıkılacak.";
 "touchbar.seek" = "Sar";
 "touchbar.time" = "Zaman Pozisyonu";
 "track.none" = "<Hiçbiri>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -191,3 +191,12 @@
 "touchbar.seek" = "Шукати";
 "touchbar.time" = "Позиція в Часі";
 "track.none" = "<Нема>";
+
+/* FIXME: Using English localization instead */
+"touchbar.remainingTime" = "Remaining Time";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -188,3 +188,9 @@
 "touchbar.time" = "播放進度";
 "touchbar.remainingTime" = "剩餘時間";
 "track.none" = "<無>";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+
+/* FIXME: Using English localization instead */
+"alert.beta_channel.title" = "Receive Updates for Beta Versions";

--- a/other/check_localizable.swift
+++ b/other/check_localizable.swift
@@ -1,0 +1,117 @@
+#!/usr/bin/xcrun swift
+
+import Cocoa
+
+extension String {
+  var escaped: String {
+    return self.replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+      .replacingOccurrences(of: "\n", with: "\\n")
+  }
+}
+
+struct StandardErrorOutputStream: TextOutputStream {
+  let stderr = FileHandle.standardError
+
+  func write(_ string: String) {
+    if let data = string.data(using: .utf8) {
+      stderr.write(data)
+    }
+  }
+}
+
+var stderr = StandardErrorOutputStream()
+
+func error(_ message: String) -> Never {
+  print(message, to: &stderr)
+  exit(1)
+}
+
+func append(_ text: String, to fileURL: URL) {
+  guard let fileHandle = try? FileHandle(forWritingTo: fileURL) else {
+    error("Cannot open file \(fileURL).")
+  }
+  fileHandle.seekToEndOfFile()
+  fileHandle.write(text.data(using: .utf8)!)
+  fileHandle.closeFile()
+}
+
+let fm = FileManager.default
+
+let callPath = CommandLine.arguments[0]
+let selfURL: URL
+
+if callPath.hasPrefix("/") {
+  selfURL = URL(fileURLWithPath: callPath)
+} else {
+  selfURL = URL(fileURLWithPath: fm.currentDirectoryPath).appendingPathComponent(callPath)
+}
+
+let projRootURL = selfURL.deletingLastPathComponent()
+  .deletingLastPathComponent()
+  .appendingPathComponent("iina", isDirectory: true)
+
+// base Localizable.strings file
+let baseFileURL = projRootURL.appendingPathComponent("Base.lproj/Localizable.strings")
+
+// lproj folders
+guard let lProjURLs = try? fm
+  .contentsOfDirectory(at: projRootURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
+  .filter { $0.hasDirectoryPath && $0.lastPathComponent.hasSuffix(".lproj") && $0.lastPathComponent != "Base.lproj" }, lProjURLs.count > 1 else {
+    error("Cannot find localization directories.")
+}
+
+print("Checking Localizable.strings for \(lProjURLs.count) localizations……")
+
+// Localizable.strings files
+let stringFileURLs = lProjURLs.map { $0.appendingPathComponent("Localizable.strings") }
+
+// make sure all files exist
+stringFileURLs.forEach { url in
+  guard fm.fileExists(atPath: url.path) else {
+    error("Localizable.strings doesn't exist.")
+  }
+}
+
+// read base file
+guard let baseDict = NSDictionary(contentsOf: baseFileURL) as? [String: String] else {
+  error("Base Localizable.strings doesn't exist.")
+}
+
+let baseKeys = baseDict.keys
+
+var missingKeys: [(String, URL)] = []
+
+// check l10n files
+for stringFileURL in stringFileURLs {
+  // read l10n file
+  guard let l10nDict = NSDictionary(contentsOf: stringFileURL) as? [String: String] else {
+    error("File \(stringFileURL.path) doesn't exist.")
+  }
+  for baseKey in baseKeys {
+    if l10nDict[baseKey] == nil {
+      missingKeys.append((baseKey, stringFileURL))
+    }
+  }
+}
+
+if CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "--fix" {
+  // fix
+  print("Fixing errors……")
+  for (key, file) in missingKeys {
+    append("""
+
+    /* FIXME: Using English localization instead */
+    "\(key)" = "\(baseDict[key]!.escaped)";
+
+    """, to: file)
+    print("Fixed \(key) in \(file.path)")
+  }
+} else {
+  // output error
+  guard missingKeys.isEmpty else {
+    error(missingKeys.map { "Missing key \"\($0.0)\" in \($0.1.path)." }.joined(separator: "\n"))
+  }
+}
+
+print("Checking Finished.")


### PR DESCRIPTION
**Description:**

Cocoa won't fallback to English localizations only for keys in `Localizable.string`; actually, build 68 already suffered from this problem due to my carelessness. Therefore I added an extra script to check missing keys in `Localizble.string` files while building.

Run `other/check_localizable.swift --fix` to fix them automatically.