### PR TITLE
FEATURE: Use macOS' default Log/Cache directories

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -39,7 +39,6 @@ struct AppData {
   static let encodings = CharEncoding.list
 
   static let userInputConfFolder = "input_conf"
-  static let logFolder = "log"
   static let watchLaterFolder = "watch_later"
   static let historyFile = "history.plist"
   static let thumbnailCacheFolder = "thumb_cache"

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -351,9 +351,9 @@ class Utility {
     // check exist
     if !FileManager.default.fileExists(atPath: path) {
       do {
-      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false, attributes: nil)
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
       } catch {
-        Utility.fatal("Cannot create folder in Application Support directory")
+        Utility.fatal("Cannot create directory: \(url)")
       }
     }
   }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -408,9 +408,14 @@ class Utility {
   }()
 
   static let thumbnailCacheURL: URL = {
-    let url = Utility.appSupportDirUrl.appendingPathComponent(AppData.thumbnailCacheFolder, isDirectory: true)
-    createDirIfNotExist(url: url)
-    return url
+    // get path
+    let cachesPath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+    Utility.assert(cachesPath.count >= 1, "Cannot get path to Caches directory")
+    let bundleID = Bundle.main.bundleIdentifier!
+    let appCachesUrl = cachesPath.first!.appendingPathComponent(bundleID, isDirectory: true)
+    let appThumbnailCacheUrl = appCachesUrl.appendingPathComponent(AppData.thumbnailCacheFolder, isDirectory: true)
+    createDirIfNotExist(url: appThumbnailCacheUrl)
+    return appThumbnailCacheUrl
   }()
 
   static let playbackHistoryURL: URL = {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -396,9 +396,14 @@ class Utility {
   }()
 
   static let logDirURL: URL = {
-    let url = Utility.appSupportDirUrl.appendingPathComponent(AppData.logFolder, isDirectory: true)
-    createDirIfNotExist(url: url)
-    return url
+    // get path
+    let libraryPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+    Utility.assert(libraryPath.count >= 1, "Cannot get path to Logs directory")
+    let logsUrl = libraryPath.first!.appendingPathComponent("Logs", isDirectory: true)
+    let bundleID = Bundle.main.bundleIdentifier!
+    let appLogsUrl = logsUrl.appendingPathComponent(bundleID, isDirectory: true)
+    createDirIfNotExist(url: appLogsUrl)
+    return appLogsUrl
   }()
 
   static let watchLaterURL: URL = {


### PR DESCRIPTION
## 📋 Description
- Log files were previously in: `~/Application Support/com.colliderli.iina/logs`
This made it impractical to use `Console.app` to view IINAs logs
- The change moves Log files to: `~/Library/Logs/com.colliderli.iina`
That allows `Console.app` to display IINAs logs live and is [standard macOS behaviour](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html)   
- Cache files were previously in: `~/Application Support/com.colliderli.iina/cache`
This impeded system maintainance and cache cleanup routines
- The change moves Cache files to: `~/Library/Caches/com.colliderli.iina`
That enables any system cleanup tools to remove IINAs cached files (e.g., thumbnails)

## 🗂 Type
 - [x] 🍾 Feature

## 🔥 Severity
- [x] 💎 Non-Breaking Changes

## 👨‍🎓 Implementation
 - [x] Pars of these changes have been previously approved by @saagarjha (#1481)
 - [x] Any required filesystem directories are automatically initialized

## 🛃 Tests
 - [x] My changes have been tested manually

