### PR TITLE
Use filename to search on OpenSubtitle

### DIFF
--- a/iina/OnlineSubtitle.swift
+++ b/iina/OnlineSubtitle.swift
@@ -98,21 +98,10 @@ class OnlineSubtitle: NSObject {
         subSupport.hash(url)
       }.then { info in
         subSupport.request(info.dictionary)
-      }.then { subs -> Promise<[OpenSubSubtitle]> in
-        if subs.isEmpty {
-          subSupport.requestIMDB(url)
-          .then { IMDB -> Promise<[OpenSubSubtitle]> in
-            let requestInfo = ["imdbid": IMDB]
-            return subSupport.request(requestInfo)
-          }.then { newSubs -> Promise<[OpenSubSubtitle]> in
-            return subSupport.showSubSelectWindow(with: newSubs)
-          }.then { selectedSubs -> Void in
-            callback(selectedSubs)
-          }.catch { err in
-            return err
-          }
-        }
-        return subSupport.showSubSelectWindow(with: subs)
+      }.then { subs in
+        subSupport.requestByName(url, subs)
+      }.then { subs in
+        subSupport.showSubSelectWindow(with: subs)
       }.then { selectedSubs -> Void in
         callback(selectedSubs)
       }.catch { err in

--- a/iina/OnlineSubtitle.swift
+++ b/iina/OnlineSubtitle.swift
@@ -98,8 +98,21 @@ class OnlineSubtitle: NSObject {
         subSupport.hash(url)
       }.then { info in
         subSupport.request(info.dictionary)
-      }.then { subs in
-        subSupport.showSubSelectWindow(with: subs)
+      }.then { subs -> Promise<[OpenSubSubtitle]> in
+        if subs.isEmpty {
+          subSupport.requestIMDB(url)
+          .then { IMDB -> Promise<[OpenSubSubtitle]> in
+            let requestInfo = ["imdbid": IMDB]
+            return subSupport.request(requestInfo)
+          }.then { newSubs -> Promise<[OpenSubSubtitle]> in
+            return subSupport.showSubSelectWindow(with: newSubs)
+          }.then { selectedSubs -> Void in
+            callback(selectedSubs)
+          }.catch { err in
+            return err
+          }
+        }
+        return subSupport.showSubSelectWindow(with: subs)
       }.then { selectedSubs -> Void in
         callback(selectedSubs)
       }.catch { err in

--- a/iina/OnlineSubtitle.swift
+++ b/iina/OnlineSubtitle.swift
@@ -97,7 +97,7 @@ class OnlineSubtitle: NSObject {
       .then { _ in
         subSupport.hash(url)
       }.then { info in
-        subSupport.request(info)
+        subSupport.request(info.dictionary)
       }.then { subs in
         subSupport.showSubSelectWindow(with: subs)
       }.then { selectedSubs -> Void in
@@ -109,12 +109,12 @@ class OnlineSubtitle: NSObject {
              OpenSubSupport.OpenSubError.fileTooSmall:
           osdMessage = .fileError
         case OpenSubSupport.OpenSubError.loginFailed(let reason):
-          Utility.log("OpenSub: \(reason)")
+          Utility.log("OpenSubtitles: \(reason)")
           osdMessage = .cannotLogin
         case OpenSubSupport.OpenSubError.userCanceled:
           osdMessage = .canceled
         case OpenSubSupport.OpenSubError.xmlRpcError(let error):
-          Utility.log("OpenSub: \(error.readableDescription)")
+          Utility.log("OpenSubtitles: \(error.readableDescription)")
           osdMessage = .networkError
         default:
           osdMessage = .networkError

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -57,6 +57,7 @@ class OpenSubSupport {
   typealias Subtitle = OpenSubSubtitle
 
   enum OpenSubError: Error {
+    case noResult
     // login failed (reason)
     case loginFailed(String)
     // file error
@@ -198,10 +199,7 @@ class OpenSubSupport {
     }
   }
 
-  func requestByName(_ fileURL: URL, _ subs: [OpenSubSubtitle]) -> Promise<[OpenSubSubtitle]> {
-    guard subs.isEmpty else {
-      return Promise { fulfill, reject in fulfill(subs) }
-    }
+  func requestByName(_ fileURL: URL) -> Promise<[OpenSubSubtitle]> {
     return requestIMDB(fileURL).then { IMDB in
       let info = ["imdbid": IMDB]
       return self.request(info)
@@ -270,7 +268,11 @@ class OpenSubSupport {
                                       zipDlLink: subData["ZipDownloadLink"] as! String)
             result.append(sub)
           }
-          fulfill(result)
+          if result.isEmpty {
+            reject(OpenSubError.noResult)
+          } else {
+            fulfill(result)
+          }
         case .failure(_):
           // Failure
           reject(OpenSubError.searchFailed("Failure"))


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #764 .

---

**Description:**
Currently IINA only uses file hash to search on OpenSubtitle.org. This PR makes IINA search again using filename when the first attempt returns no result.

<s>Besides, this PR also fix a bug in the OpenSubtitle part. I'm not sure whether this bug exists for a long time or is due to OpenSubtitle's API change.</s> (Due to a temporary API change of opensubtitle)