### PR TITLE
Automatically switch to music mode when the file has multiple artwork images

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1368,8 +1368,8 @@ class PlayerCore: NSObject {
     if noVideoTrack && noAudioTrack {
       return .unknown
     }
-    let theOnlyVideoTrackIsAlbumCover = info.videoTracks.count == 1 && info.videoTracks.first!.isAlbumart
-    return (noVideoTrack || theOnlyVideoTrackIsAlbumCover) ? .isAudio : .notAudio
+    let allVideoTracksAreAlbumCover = !info.videoTracks.contains { !$0.isAlbumart }
+    return (noVideoTrack || allVideoTracksAreAlbumCover) ? .isAudio : .notAudio
   }
 
   static func checkStatusForSleep() {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #1524.

---

**Description:**

Currently IINA does not switch to Music Mode if the audio file has multiple artwork images. With this change it checks that every video track is an artwork image.