### PR TITLE
Properly disable Initial window size controls on launch

### DIFF
--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -172,21 +172,21 @@ class PrefUIViewController: NSViewController, MASPreferencesViewController {
       // size
       if let h = geometry.h {
         windowSizeCheckBox.state = .on
-        setSubViews(of: windowPosBox, enabled: true)
+        setSubViews(of: windowSizeBox, enabled: true)
         windowSizeTypePopUpButton.selectItem(withTag: SizeHeightTag)
         let isPercent = h.hasSuffix("%")
         windowSizeUnitPopUpButton.selectItem(withTag: isPercent ? UnitPercentTag : UnitPointTag)
         windowSizeValueTextField.stringValue = isPercent ? String(h.dropLast()) : h
       } else if let w = geometry.w {
         windowSizeCheckBox.state = .on
-        setSubViews(of: windowPosBox, enabled: true)
+        setSubViews(of: windowSizeBox, enabled: true)
         windowSizeTypePopUpButton.selectItem(withTag: SizeWidthTag)
         let isPercent = w.hasSuffix("%")
         windowSizeUnitPopUpButton.selectItem(withTag: isPercent ? UnitPercentTag : UnitPointTag)
         windowSizeValueTextField.stringValue = isPercent ? String(w.dropLast()) : w
       } else {
         windowSizeCheckBox.state = .off
-        setSubViews(of: windowPosBox, enabled: false)
+        setSubViews(of: windowSizeBox, enabled: false)
       }
       // position
       if let x = geometry.x, let xSign = geometry.xSign, let y = geometry.y, let ySign = geometry.ySign {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

When ```Initial window size``` was unchecked, the related controls weren't disabled on launch, because it was disabling the controls for ```Initial window position``` instead.