### PR TITLE
Fix order of artist and album in Music Mode

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -248,7 +248,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate {
   @objc
   func updateTrack() {
     DispatchQueue.main.async {
-      let (mediaTitle, mediaArtist, mediaAlbum) = self.player.getMusicMetadata()
+      let (mediaTitle, mediaAlbum, mediaArtist) = self.player.getMusicMetadata()
       self.titleLabel.stringValue = mediaTitle
       self.window?.title = mediaTitle
       // hide artist & album label when info not available


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

[PlayerCore.getMusicMetadata()](https://github.com/lhc70000/iina/blob/develop/iina/PlayerCore.swift#L1316-L1321) returns the tuple ```(title, album, artist)```, but the mini player assumed the order was ```(title, artist, album)```. This caused the mini player UI to display "Album - Artist" instead of "Artist - Album".

![](https://puu.sh/zPXMC/b0985d7a79.png)