### PR TITLE
Fix ab loop stays even when switching media files

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -274,6 +274,7 @@ class MPVController: NSObject {
 
     setUserOption(PK.ytdlEnabled, type: .bool, forName: MPVOption.ProgramBehavior.ytdl)
     setUserOption(PK.ytdlRawOptions, type: .string, forName: MPVOption.ProgramBehavior.ytdlRawOptions)
+    chkErr(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.resetOnNextFile, "ab-loop-a,ab-loop-b"))
 
     // Set user defined conf dir.
     if Preference.bool(for: .useUserDefinedConfDir) {

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -274,7 +274,8 @@ class MPVController: NSObject {
 
     setUserOption(PK.ytdlEnabled, type: .bool, forName: MPVOption.ProgramBehavior.ytdl)
     setUserOption(PK.ytdlRawOptions, type: .string, forName: MPVOption.ProgramBehavior.ytdlRawOptions)
-    chkErr(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.resetOnNextFile, "ab-loop-a,ab-loop-b"))
+    chkErr(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.resetOnNextFile,
+            "\(MPVOption.PlaybackControl.abLoopA),\(MPVOption.PlaybackControl.abLoopB)"))
 
     // Set user defined conf dir.
     if Preference.bool(for: .useUserDefinedConfDir) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -447,9 +447,6 @@ class PlayerCore: NSObject {
     let a = mpv.getDouble(MPVOption.PlaybackControl.abLoopA)
     let b = mpv.getDouble(MPVOption.PlaybackControl.abLoopB)
     if a != 0 || b != 0 {
-      mpv.setDouble(MPVOption.PlaybackControl.abLoopA, 0)
-      mpv.setDouble(MPVOption.PlaybackControl.abLoopB, 0)
-      mpv.command(.abLoop)
       info.abLoopStatus = 0
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -444,10 +444,12 @@ class PlayerCore: NSObject {
   }
 
   func clearAbLoop() {
-    let a = mpv.getDouble(MPVOption.PlaybackControl.abLoopA)
-    let b = mpv.getDouble(MPVOption.PlaybackControl.abLoopB)
-    if a != 0 || b != 0 {
-      info.abLoopStatus = 0
+    if let resetOption = mpv.getString(MPVOption.ProgramBehavior.resetOnNextFile) {
+        if resetOption.contains(MPVOption.PlaybackControl.abLoopA) &&
+                   resetOption.contains(MPVOption.PlaybackControl.abLoopB) {
+          info.abLoopStatus = 0
+          sendOSD(.abLoop(info.abLoopStatus))
+      }
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -443,6 +443,17 @@ class PlayerCore: NSObject {
     sendOSD(.abLoop(info.abLoopStatus))
   }
 
+  func clearAbLoop() {
+    let a = mpv.getDouble(MPVOption.PlaybackControl.abLoopA)
+    let b = mpv.getDouble(MPVOption.PlaybackControl.abLoopB)
+    if a != 0 || b != 0 {
+      mpv.setDouble(MPVOption.PlaybackControl.abLoopA, 0)
+      mpv.setDouble(MPVOption.PlaybackControl.abLoopB, 0)
+      mpv.command(.abLoop)
+      info.abLoopStatus = 0
+    }
+  }
+
   func toggleFileLoop() {
     let isLoop = mpv.getFlag(MPVOption.PlaybackControl.loopFile)
     mpv.setFlag(MPVOption.PlaybackControl.loopFile, !isLoop)
@@ -902,6 +913,7 @@ class PlayerCore: NSObject {
     getSelectedTracks()
     getPlaylist()
     getChapters()
+    clearAbLoop()
     DispatchQueue.main.sync {
       syncPlayTimeTimer = Timer.scheduledTimer(timeInterval: TimeInterval(AppData.getTimeInterval),
                                                target: self, selector: #selector(self.syncUITime), userInfo: nil, repeats: true)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #917 .

---

**Description:**

It seems that mpv retains the status of ab loop even when switching files in playlist or play next/prev. Added clearing ab loop when a new files is loaded.