### PR TITLE
Make `FontPickerWindowController` shows up quicker.

### DIFF
--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -30,6 +30,9 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
 
   var finishedPicking: ((String?) -> Void)?
 
+  let fontNameQueue: DispatchQueue = DispatchQueue(label: "IINAFontTask")
+  let fontNameTask = DispatchGroup()
+
   override var windowNibName: NSNib.Name {
     get {
       return NSNib.Name("FontPickerWindowController")
@@ -38,6 +41,8 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
 
   override func windowDidLoad() {
     super.windowDidLoad()
+
+    fontNameTask.wait()
 
     withAllTableViews { tv in
       tv.dataSource = self

--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -39,12 +39,6 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   override func windowDidLoad() {
     super.windowDidLoad()
 
-    let manager = NSFontManager.shared
-
-    fontNames = manager.availableFontFamilies
-      .filter { !$0.hasPrefix(".") && !$0.trimmingCharacters(in: .whitespaces).isEmpty }
-      .map { FontInfo(name: $0, localizedName: manager.localizedName(forFamily: $0, face: nil)) }
-      .sorted { $0.localizedName < $1.localizedName }
     withAllTableViews { tv in
       tv.dataSource = self
       tv.delegate = self

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -34,6 +34,8 @@ class PrefSubViewController: NSViewController {
   @IBOutlet weak var loginIndicator: NSProgressIndicator!
   @IBOutlet weak var defaultEncodingList: NSPopUpButton!
 
+  let fontNameQueue: DispatchQueue = DispatchQueue(label: "IINAFontTask")
+
   override func viewDidLoad() {
     super.viewDidLoad()
     
@@ -48,6 +50,15 @@ class PrefSubViewController: NSViewController {
     }
     
     defaultEncodingList.menu?.insertItem(NSMenuItem.separator(), at: 1)
+
+    fontNameQueue.async {
+      let manager = NSFontManager.shared
+
+      (NSApp.delegate as! AppDelegate).fontPicker.fontNames = manager.availableFontFamilies
+        .filter { !$0.hasPrefix(".") && !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        .map { FontPickerWindowController.FontInfo(name: $0, localizedName: manager.localizedName(forFamily: $0, face: nil)) }
+        .sorted { $0.localizedName < $1.localizedName }
+    }
 
     subLangTokenView.delegate = self
     loginIndicator.isHidden = true

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -34,8 +34,6 @@ class PrefSubViewController: NSViewController {
   @IBOutlet weak var loginIndicator: NSProgressIndicator!
   @IBOutlet weak var defaultEncodingList: NSPopUpButton!
 
-  let fontNameQueue: DispatchQueue = DispatchQueue(label: "IINAFontTask")
-
   override func viewDidLoad() {
     super.viewDidLoad()
     
@@ -51,13 +49,18 @@ class PrefSubViewController: NSViewController {
     
     defaultEncodingList.menu?.insertItem(NSMenuItem.separator(), at: 1)
 
-    fontNameQueue.async {
+    let fontPicker = (NSApp.delegate as! AppDelegate).fontPicker
+
+    fontPicker.fontNameTask.enter()
+    fontPicker.fontNameQueue.async {
       let manager = NSFontManager.shared
 
-      (NSApp.delegate as! AppDelegate).fontPicker.fontNames = manager.availableFontFamilies
+      fontPicker.fontNames = manager.availableFontFamilies
         .filter { !$0.hasPrefix(".") && !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         .map { FontPickerWindowController.FontInfo(name: $0, localizedName: manager.localizedName(forFamily: $0, face: nil)) }
         .sorted { $0.localizedName < $1.localizedName }
+
+      fontPicker.fontNameTask.leave()
     }
 
     subLangTokenView.delegate = self


### PR DESCRIPTION
**Description:**
When opening font picker window, there is a noticeable delay (~0.7s, ~260 fonts) until it shows up. Based on my investigation, this maybe caused by `NSFontManager.localizedName(forFamily: String, face: String?)`. Seems to be inevitable, so that in order to prevent that delay, I move the code block where calls this method to `PrefSubViewController` and call it in an asynchronous way.