### PR TITLE
Add function to select None subtitle in menu, fix #1653

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -60,7 +60,7 @@
 "osd.video_eq.saturation" = "Saturation: %i";
 "osd.video_eq.brightness" = "Brightness: %i";
 "osd.find_online_sub" = "Finding online subtitles...";
-"osd.sub_not_found" = "No subtitle found";
+"osd.sub_not_found" = "No subtitles found";
 "osd.sub_found" = "%d subtitle(s) found. Downloading...";
 "osd.sub_downloaded" = "Subtitle downloaded";
 "osd.sub_saved" = "Subtitle saved";
@@ -109,8 +109,8 @@
 
 "track.none" = "<None>";
 
-"subtrack.no_loaded" = "No subtitle loaded";
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_loaded" = "No Subtitles Loaded";
+"subtrack.no_external" = "No External Subtitles Found";
 
 // Alerts
 "alert.beta_channel.title" = "Receive Updates for Beta Versions";
@@ -160,7 +160,7 @@
 "alert.playlist.error_deleting" = "Error deleting: %@";
 
 "alert.sub.no_selected" = "Please select a downloaded subtitle first.";
-"alert.sub_lang_not_set" = "Please set preferred subtitle language in preferences before using opensubtitles. English(eng) will be used this time.";
+"alert.sub_lang_not_set" = "Please set preferred subtitle language in preferences before using OpenSubtitles. English(eng) will be used this time.";
 "alert.sub.cannot_save_passwd" = "Cannot save your password to Keychain: %@";
 "alert.sub.cannot_login" = "Cannot login. Please check your username, password and network status.\n\n%@";
 

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -109,6 +109,9 @@
 
 "track.none" = "<None>";
 
+"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_external" = "No external subtitle found";
+
 // Alerts
 "alert.beta_channel.title" = "Receive Updates for Beta Versions";
 "alert.beta_channel.message" = "IINA v1.0 is comming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -258,7 +258,7 @@ enum OSDMessage {
 
     case .foundSub(let count):
       let str = count == 0 ?
-        NSLocalizedString("osd.sub_not_found", comment: "No subtitle found.") :
+        NSLocalizedString("osd.sub_not_found", comment: "No subtitles found.") :
         String(format: NSLocalizedString("osd.sub_found", comment: "%d subtitle(s) found. Downloading..."), count)
       return (str, .normal)
 

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -601,8 +601,18 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     // loaded subtitles
     if showLoadedSubs {
       if player.info.subTracks.isEmpty {
-        menu.addItem(withTitle: NSLocalizedString("track.none", comment: "<None>"))
+        let item = NSMenuItem()
+        item.title = NSLocalizedString("subtrack.no_loaded", comment: "No subtitle loaded")
+        item.isEnabled = false
+        menu.addItem(item)
       } else {
+        let empty = NSMenuItem()
+        empty.title = NSLocalizedString("track.none", comment: "<None>")
+        empty.target = self
+        empty.action = #selector(self.chosenSubFromMenu(_:))
+        empty.representedObject = nil
+        empty.state = player.info.sid == 0 ? .on : .off
+        menu.addItem(empty)
         for sub in player.info.subTracks {
           let item = NSMenuItem()
           item.title = sub.readableTitle
@@ -627,7 +637,10 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       menu.addItem(item)
     }
     if player.info.currentSubsInfo.isEmpty {
-      menu.addItem(withTitle: NSLocalizedString("track.none", comment: "<None>"))
+      let item = NSMenuItem()
+      item.title = NSLocalizedString("subtrack.no_external", comment: "No external subtitle found")
+      item.isEnabled = false
+      menu.addItem(item)
     } else {
       if let videoInfo = player.info.currentVideosInfo.first(where: { $0.url == player.info.currentURL }),
         !videoInfo.relatedSubs.isEmpty {
@@ -646,6 +659,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       player.loadExternalSubFile(fileInfo.url)
     } else if let sub = sender.representedObject as? MPVTrack {
       player.setTrack(sub.id, forType: .sub)
+    } else {
+      player.setTrack(0, forType: .sub)
     }
   }
 

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -602,7 +602,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     if showLoadedSubs {
       if player.info.subTracks.isEmpty {
         let item = NSMenuItem()
-        item.title = NSLocalizedString("subtrack.no_loaded", comment: "No subtitle loaded")
+        item.title = NSLocalizedString("subtrack.no_loaded", comment: "No subtitles loaded")
         item.isEnabled = false
         menu.addItem(item)
       } else {
@@ -638,7 +638,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     if player.info.currentSubsInfo.isEmpty {
       let item = NSMenuItem()
-      item.title = NSLocalizedString("subtrack.no_external", comment: "No external subtitle found")
+      item.title = NSLocalizedString("subtrack.no_external", comment: "No external subtitles found")
       item.isEnabled = false
       menu.addItem(item)
     } else {

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -247,3 +247,9 @@ Programmet afsluttes.";
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -249,7 +249,7 @@ Programmet afsluttes.";
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -258,3 +258,9 @@
 "touchbar.seek" = "탐색";
 "touchbar.time" = "재생 위치";
 "touchbar.remainingTime" = "남은 시간";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -260,7 +260,7 @@
 "touchbar.remainingTime" = "남은 시간";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -214,3 +214,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -297,7 +297,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -295,3 +295,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -248,3 +248,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -250,7 +250,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -205,3 +205,9 @@
 "touchbar.seek" = "Vyhľadať";
 "touchbar.time" = "Pozícia";
 "track.none" = "<Prázdne>";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -145,7 +145,7 @@
 "osd.sub_delay.nodelay" = "Oneskorenie Titulkov: Žiadne Oneskorenie";
 "osd.sub_downloaded" = "Titulky stiahnuté";
 "osd.sub_found" = "%d titulky nájdené. Sťahujú sa...";
-"osd.sub_not_found" = "No subtitle found";
+"osd.sub_not_found" = "No subtitles found";
 "osd.sub_saved" = "Titulky uložené";
 "osd.subtitle_pos" = "Oneskorenie Titulkov: %.1f";
 "osd.subtitle_scale" = "Veľkosť Titulkov: %.2fx";
@@ -207,7 +207,7 @@
 "track.none" = "<Prázdne>";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -207,7 +207,7 @@
 "track.none" = "<Hiçbiri>";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -205,3 +205,9 @@
 "touchbar.seek" = "Sar";
 "touchbar.time" = "Zaman Pozisyonu";
 "track.none" = "<Hiçbiri>";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -248,3 +248,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -250,7 +250,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -205,3 +205,5 @@
 "touchbar.seek" = "进度条";
 "touchbar.time" = "播放进度";
 "track.none" = "<无>";
+"subtrack.no_loaded" = "没有已加载的字幕";
+"subtrack.no_external" = "没有找到外部字幕";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -242,3 +242,9 @@
 
 /* FIXME: Using English localization instead */
 "pl_menu.add_url" = "Add URL…";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_external" = "No external subtitle found";
+
+/* FIXME: Using English localization instead */
+"subtrack.no_loaded" = "No subtitle loaded";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -244,7 +244,7 @@
 "pl_menu.add_url" = "Add URL…";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_external" = "No external subtitle found";
+"subtrack.no_external" = "No External Subtitles Found";
 
 /* FIXME: Using English localization instead */
-"subtrack.no_loaded" = "No subtitle loaded";
+"subtrack.no_loaded" = "No Subtitles Loaded";


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #1653 .

---

**Description:**
Add function to select None subtitle in menu; use "No subtitle loaded" and "No external subtitle found" instead of "\<None\>" when no suitable subtitle.

Before: <img width="524" alt="screen shot 2018-04-28 at 12 18 13" src="https://user-images.githubusercontent.com/2270433/39394750-51598328-4ade-11e8-8fa0-79c0ef3334a8.png">

After: ![image](https://user-images.githubusercontent.com/20237141/39412015-d77a062e-4bda-11e8-8ed6-6747a4ca183f.png)
Click "\<None\>" here now switch to \<None\>.

In case of there's no loaded subtitle and no external found:
![image](https://user-images.githubusercontent.com/20237141/39412019-fa510986-4bda-11e8-8702-42054be99aae.png)

