### PR TITLE
Fix #1624 by having the OSC buttons refuse first responder

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -686,6 +686,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       button.action = #selector(self.toolBarButtonAction(_:))
       button.tag = buttonType.rawValue
       button.translatesAutoresizingMaskIntoConstraints = false
+      button.refusesFirstResponder = true
       let buttonWidth = buttons.count == 5 ? "20" : "24"
       Utility.quickConstraints(["H:[btn(\(buttonWidth))]", "V:[btn(24)]"], ["btn": button])
       fragToolbarView.addView(button, in: .trailing)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [X] It implements / fixes issue #1624.

---

**Description:**
Quick fix for #1624, which has been bothering me as well. It seems that Interface Builder sets `refusesFirstResponder` to `true` by default, but the regular `NSButton` initializer doesn't.