### PR TITLE
Respect "Show remaining time" preference in Music Mode

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -171,6 +171,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
 
     updateVolume()
     updatePlayButtonState(player.info.isPaused ? .off : .on)
+    rightLabel.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .duration
 
     if Preference.bool(for: .alwaysFloatOnTop) {
       setWindowFloatingOnTop(true)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
When changing the "Show remaining time" preference, the change is immediately visible in the OSC. However, after restarting IINA, Music Mode always shows the duration.