### PR TITLE
Fix mouse tracking issue in macOS 10.14

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1190,13 +1190,13 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     // update buffer indicator view
     updateBufferIndicatorView()
     // start tracking mouse event
-    guard let w = self.window, let cv = w.contentView else { return }
-    if cv.trackingAreas.isEmpty {
+    guard let w = self.window, let cv = w.contentView?.superview else { return }
+    if cv.trackingAreas.filter ({ $0.owner === self as AnyObject }).isEmpty {
       cv.addTrackingArea(NSTrackingArea(rect: cv.bounds,
                                         options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
                                         owner: self, userInfo: ["obj": 0]))
     }
-    if playSlider.trackingAreas.isEmpty {
+    if playSlider.trackingAreas.filter ({ $0.owner === self as AnyObject }).isEmpty {
       playSlider.addTrackingArea(NSTrackingArea(rect: playSlider.bounds,
                                                 options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
                                                 owner: self, userInfo: ["obj": 1]))
@@ -1233,9 +1233,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     player.info.currentFolder = nil
     player.info.matchedSubs.removeAll()
     // stop tracking mouse event
-    guard let w = self.window, let cv = w.contentView else { return }
-    cv.trackingAreas.forEach(cv.removeTrackingArea)
-    playSlider.trackingAreas.forEach(playSlider.removeTrackingArea)
+    guard let w = self.window, let cv = w.contentView?.superview else { return }
+    cv.trackingAreas.filter { $0.owner === self as AnyObject }.forEach { cv.removeTrackingArea($0) }
+    playSlider.trackingAreas.filter { $0.owner === self as AnyObject }.forEach { playSlider.removeTrackingArea($0) }
   }
 
   // MARK: - Window delegate: Full screen


### PR DESCRIPTION
In mojave, titlebar seems overlap content view for some reason; If we still add tracking area on main window's content view, then the system will call mouseExit when we move the mouse to the titlebar. Adding tracking area on content view's super view can fix this.