### PR TITLE
Monospaced font for time labels in OSC and Touch Bar

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -389,6 +389,9 @@
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="font" keyPath="monospacedFont" id="uHM-ya-PZy"/>
+                    </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GgV-Cc-sk0" userLabel="Right Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="450" y="5" width="50" height="14"/>
@@ -400,6 +403,9 @@
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="font" keyPath="monospacedFont" id="6lX-sn-136"/>
+                    </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qOq-6a-7j7">
                     <rect key="frame" x="196" y="11" width="44" height="12"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -43,10 +43,11 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @objc let monospacedFont: NSFont = {
+    let fontSize = NSFont.systemFontSize(for: .small)
     if #available(OSX 10.11, *) {
-      return NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+      return NSFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
     } else {
-      return NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+      return NSFont.systemFont(ofSize: fontSize)
     }
   }()
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -42,6 +42,14 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     return NSNib.Name("MainWindowController")
   }
 
+  @objc let monospacedFont: NSFont = {
+    if #available(OSX 10.11, *) {
+      return NSFont.monospacedDigitSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+    } else {
+      return NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+    }
+  }()
+
   // MARK: - Constants
 
   /** Minimum window size. */

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -21,10 +21,11 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
   }
 
   @objc let monospacedFont: NSFont = {
+    let fontSize = NSFont.systemFontSize(for: .mini)
     if #available(OSX 10.11, *) {
-      return NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .regular)
+      return NSFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
     } else {
-      return NSFont.systemFont(ofSize: 9)
+      return NSFont.systemFont(ofSize: fontSize)
     }
   }()
 

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -20,6 +20,14 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     return NSNib.Name("MiniPlayerWindowController")
   }
 
+  @objc let monospacedFont: NSFont = {
+    if #available(OSX 10.11, *) {
+      return NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .regular)
+    } else {
+      return NSFont.systemFont(ofSize: 9)
+    }
+  }()
+
   unowned var player: PlayerCore
 
   var menuActionHandler: MainMenuActionHandler!

--- a/iina/MiniPlayerWindowController.xib
+++ b/iina/MiniPlayerWindowController.xib
@@ -83,6 +83,9 @@
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="TM3-Ri-L7h"/>
+                                </connections>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf">
                                 <rect key="frame" x="4" y="10" width="36" height="11"/>
@@ -94,6 +97,9 @@
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="ivC-kT-hEO"/>
+                                </connections>
                             </textField>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="e3M-Ma-JJM">
                                 <rect key="frame" x="44" y="8" width="212" height="15"/>

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -118,6 +118,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       let item = NSCustomTouchBarItem(identifier: identifier)
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
+      label.font = .monospacedDigitSystemFont(ofSize: 0, weight: .regular)
       label.mode = .current
       self.touchBarPosLabels.append(label)
       item.view = label
@@ -128,6 +129,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       let item = NSCustomTouchBarItem(identifier: identifier)
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
+      label.font = .monospacedDigitSystemFont(ofSize: 0, weight: .regular)
       label.mode = .remaining
       self.touchBarPosLabels.append(label)
       item.view = label


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #1377.

---

**Description:**
I couldn't find a constant for the System Mini font size (9pt) for the mini player, so it's hardcoded.
