### PR TITLE
Refactor on `PlayerCore.openURL(s)`

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -196,10 +196,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         if commandLineStatus.openSeparateWindows {
           validFileURLs.forEach { url in
-            let _ = getNewPlayerCore().openURLs([url])
+            getNewPlayerCore().openURL(url)
           }
         } else {
-          let _ = getNewPlayerCore().openURLs(validFileURLs)
+          getNewPlayerCore().openURLs(validFileURLs)
         }
       }
     }
@@ -285,7 +285,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let urls = pendingFilesForOpenFile.map { URL(fileURLWithPath: $0) }
 
     pendingFilesForOpenFile.removeAll()
-    if let openedFileCount = PlayerCore.activeOrNew.openURLs(urls), openedFileCount == 0 {
+    if PlayerCore.activeOrNew.openURLs(urls) == 0 {
       Utility.showAlert("nothing_to_open")
     }
   }
@@ -356,7 +356,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       }
       let isAlternative = (sender as? NSMenuItem)?.tag == AlternativeMenuItemTag
       let playerCore = PlayerCore.activeOrNewForMenuAction(isAlternative: isAlternative)
-      if let openedFileCount = playerCore.openURLs(panel.urls), openedFileCount == 0 {
+      if playerCore.openURLs(panel.urls) == 0 {
         Utility.showAlert("nothing_to_open")
       }
     }

--- a/iina/DraggingDetect.swift
+++ b/iina/DraggingDetect.swift
@@ -129,7 +129,8 @@ extension PlayerCore {
     guard let types = pb.types else { return [] }
 
     if types.contains(.nsFilenames) {
-      guard let paths = pb.propertyList(forType: .nsFilenames) as? [String] else { return [] }
+      guard var paths = pb.propertyList(forType: .nsFilenames) as? [String] else { return [] }
+      paths = Utility.resolvePaths(paths)
       // check 3d lut files
       if paths.count == 1 && Utility.lut3dExt.contains(paths[0].lowercasedPathExtension) {
         return .copy
@@ -163,7 +164,8 @@ extension PlayerCore {
     guard let types = pb.types else { return false }
 
     if types.contains(.nsFilenames) {
-      guard let paths = pb.propertyList(forType: .nsFilenames) as? [String] else { return false }
+      guard var paths = pb.propertyList(forType: .nsFilenames) as? [String] else { return false }
+      paths = Utility.resolvePaths(paths)
       // check 3d lut files
       if paths.count == 1 && Utility.lut3dExt.contains(paths[0].lowercasedPathExtension) {
         let result = addVideoFilter(MPVFilter(lavfiName: "lut3d", label: "iina_quickl3d", paramDict: [

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -113,7 +113,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   @objc func doubleAction() {
     if let selected = outlineView.item(atRow: outlineView.clickedRow) as? PlaybackHistory {
-      PlayerCore.activeOrNew.openURL(selected.url, shouldAutoLoad: true)
+      PlayerCore.activeOrNew.openURL(selected.url)
     }
   }
 
@@ -237,12 +237,12 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   @IBAction func playAction(_ sender: AnyObject) {
     guard let firstEntry = selectedEntries.first else { return }
-    PlayerCore.active.openURL(firstEntry.url, shouldAutoLoad: true)
+    PlayerCore.active.openURL(firstEntry.url)
   }
 
   @IBAction func playInNewWindowAction(_ sender: AnyObject) {
     guard let firstEntry = selectedEntries.first else { return }
-    PlayerCore.newPlayerCore.openURL(firstEntry.url, shouldAutoLoad: true)
+    PlayerCore.newPlayerCore.openURL(firstEntry.url)
   }
 
   @IBAction func groupByChangedAction(_ sender: NSPopUpButton) {

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -123,7 +123,7 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
 
   func tableViewSelectionDidChange(_ notification: Notification) {
     guard let url = recentDocuments[at: recentFilesTableView.selectedRow] else { return }
-    let _ = player.openURLs([url])
+    player.openURL(url)
     recentFilesTableView.deselectAll(nil)
   }
 
@@ -183,7 +183,7 @@ class InitialWindowViewActionButton: NSView {
     } else {
       if let lastFile = Preference.url(for: .iinaLastPlayedFilePath),
         let windowController = window?.windowController as? InitialWindowController {
-        let _ = windowController.player.openURLs([lastFile])
+        windowController.player.openURL(lastFile)
       }
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -170,6 +170,7 @@ class PlayerCore: NSObject {
   @discardableResult
   func openURLs(_ urls: [URL], shouldAutoLoad autoLoad: Bool = true) -> Int? {
     guard !urls.isEmpty else { return 0 }
+    var urls = Utility.resolveURLs(urls)
     
     // handle BD folders and m3u / m3u8 files first
     if urls.count == 1 && (isBDFolder(urls[0]) ||

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -146,7 +146,7 @@ class PlayerCore: NSObject {
 
   // MARK: - Control
 
-  func openURL(_ url: URL?, shouldAutoLoad: Bool = false) {
+  private func open(_ url: URL?, shouldAutoLoad: Bool = false) {
     guard let url = url else {
       Logger.log("empty file path or url", level: .error, subsystem: subsystem)
       return
@@ -160,21 +160,6 @@ class PlayerCore: NSObject {
     openMainWindow(path: path, url: url, isNetwork: isNetwork)
   }
 
-  func openURLString(_ str: String) {
-    if str == "-" {
-      openMainWindow(path: str, url: URL(string: "stdin")!, isNetwork: false)
-    } else if str.first == "/" {
-      let url = URL(fileURLWithPath: str)
-      openMainWindow(path: str, url: url, isNetwork: false)
-    } else {
-      guard let pstr = str.addingPercentEncoding(withAllowedCharacters: .urlAllowed), let url = URL(string: pstr) else {
-        Logger.log("Cannot add percent encoding for \(str)", level: .error, subsystem: subsystem)
-        return
-      }
-      openMainWindow(path: str, url: url, isNetwork: true)
-    }
-  }
-  
   /**
    Open a list of urls. If there are more than one urls, add the remaining ones to
    playlist and disable auto loading.
@@ -182,6 +167,7 @@ class PlayerCore: NSObject {
    - Returns: `nil` if no futher action is needed, like opened a BD Folder; otherwise the
    count of playable files.
    */
+  @discardableResult
   func openURLs(_ urls: [URL], shouldAutoLoad autoLoad: Bool = true) -> Int? {
     guard !urls.isEmpty else { return 0 }
     
@@ -189,7 +175,7 @@ class PlayerCore: NSObject {
     if urls.count == 1 && (isBDFolder(urls[0]) ||
       Utility.playlistFileExt.contains(urls[0].absoluteString.lowercasedPathExtension)) {
       info.shouldAutoLoadFiles = false
-      openURL(urls[0])
+      open(urls[0])
       return nil
     }
     
@@ -208,7 +194,7 @@ class PlayerCore: NSObject {
     }
     
     // open the first file
-    openURL(playableFiles[0])
+    open(playableFiles[0])
     // add the remaining to playlist
     for i in 1..<count {
       addToPlaylist(playableFiles[i].path)
@@ -222,6 +208,27 @@ class PlayerCore: NSObject {
     }
     return count
   }
+
+  func openURL(_ url: URL, shouldAutoLoad: Bool = true) {
+    openURLs([url], shouldAutoLoad: shouldAutoLoad)
+  }
+
+  func openURLString(_ str: String) {
+    if str == "-" {
+      openMainWindow(path: str, url: URL(string: "stdin")!, isNetwork: false)
+      return
+    }
+    if str.first == "/" {
+      openURL(URL(fileURLWithPath: str))
+    } else {
+      guard let pstr = str.addingPercentEncoding(withAllowedCharacters: .urlAllowed), let url = URL(string: pstr) else {
+        Logger.log("Cannot add percent encoding for \(str)", level: .error, subsystem: subsystem)
+        return
+      }
+      openURL(url)
+    }
+  }
+
 
   private func openMainWindow(path: String, url: URL, isNetwork: Bool) {
     Logger.log("Opening \(path) in main window", subsystem: subsystem)

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -243,7 +243,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
         player.addToPlaylist(paths: before, at: 0)
       }
     } else if let paths = pasteboard.propertyList(forType: .nsFilenames) as? [String] {
-      let playableFiles = player.getPlayableFiles(in: paths.map{ URL(fileURLWithPath: $0) })
+      let playableFiles = Utility.resolveURLs(player.getPlayableFiles(in: paths.map{ URL(fileURLWithPath: $0) }))
       if playableFiles.count == 0 {
         return false
       }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -505,7 +505,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     let files = selectedRows!.enumerated().map { (_, i) in
       URL(fileURLWithPath: player.info.playlist[i].filename)
     }
-    let _ = PlayerCore.newPlayerCore.openURLs(files, shouldAutoLoad: false)
+    PlayerCore.newPlayerCore.openURLs(files, shouldAutoLoad: false)
   }
 
   @IBAction func contextMenuRemove(_ sender: NSMenuItem) {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -544,6 +544,13 @@ class Utility {
     }
   }
 
+  static func resolvePaths(_ paths: [String]) -> [String] {
+    return paths.map { (try? URL(resolvingAliasFileAt: URL(fileURLWithPath: $0)))?.path ?? $0 }
+  }
+
+  static func resolveURLs(_ urls: [URL]) -> [URL] {
+    return urls.map { (try? URL(resolvingAliasFileAt: $0)) ?? $0 }
+  }
 
 }
 


### PR DESCRIPTION
- Make the original `openURL` private; every other public `openURL` must
call the new `open` method.
- Three public `openURL` methods:
  - `openURLs`
  - `openURL`
  - `openURLString`

  Make `openURLString` always calls `openURL`, `openURL` always calls `openURLs`
  to ensure all public method calls must pass `openURLs`, hence we can
  handle BD folders/playlist files correctly.

- Fix #1831 by resolving alias