### PR TITLE
Respect theme settings in additionalInfoView 

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2076,7 +2076,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     sliderCell?.isInDarkTheme = isDarkTheme
     volumeCell?.isInDarkTheme = isDarkTheme
 
-    [titleBarView, controlBarFloating, controlBarBottom, osdVisualEffectView, pipOverlayView].forEach {
+    [titleBarView, controlBarFloating, controlBarBottom, osdVisualEffectView, pipOverlayView, additionalInfoView].forEach {
       $0?.material = material
       $0?.appearance = appearance
     }


### PR DESCRIPTION
All float views respect theme settings, but additionalInfoView all time light-gray. For example:

<img width="1440" alt="2018-07-16 18 22 45" src="https://user-images.githubusercontent.com/4497128/42767331-643c9df6-8925-11e8-930b-5b30b95ef069.png">

This PR fix that