### PR TITLE
Automatically switch to Music Mode for audio URLs

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1495,7 +1495,6 @@ class PlayerCore: NSObject {
   var currentMediaIsAudio = CurrentMediaIsAudioStatus.unknown
 
   func checkCurrentMediaIsAudio() -> CurrentMediaIsAudioStatus {
-    guard !info.isNetworkResource else { return .notAudio }
     let noVideoTrack = info.videoTracks.isEmpty
     let noAudioTrack = info.audioTracks.isEmpty
     if noVideoTrack && noAudioTrack {


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #1852.

---

**Description:**
I don't believe this guard is needed (anymore?). The rest of the function works fine for URLs.