### PR TITLE
FEATURE: Enqueue Playlist Items via the iina:// URL Scheme

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -329,12 +329,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // links
     if let host = parsed.host, host == "weblink" {
 
+      // parameter: url
       guard let urlValue = (parsed.queryItems?.first { $0.name == "url" }?.value) else {
         Logger.log("No parameter \"url\" for weblink")
         return
       }
-      Logger.log("Got weblink, url=\(urlValue)")
-      PlayerCore.active.openURLString(urlValue)
+
+      // parameter: add
+      var add = false
+      if let addValue = parsed.queryItems?.first(where: { $0.name == "add" })?.value {
+        add = NSString(string: addValue).boolValue
+      }
+
+      Logger.log("Got weblink, url=\(urlValue), add=\(add)")
+
+      if (!add) {
+        PlayerCore.active.openURLString(urlValue)
+      } else {
+        let playerCore = PlayerCore.lastActive
+        playerCore.addToPlaylist(urlValue)
+        playerCore.syncUI(.playlist)
+        playerCore.sendOSD(.addToPlaylist(2))
+      }
     }
   }
 


### PR DESCRIPTION
## ⛔️ Issue
 - Currently, opening URLs via the `iina://` URL scheme always replaces the current playlist – non-destructive alternatives are unavailable.
 - Example URL:
  `iina://weblink?url=https://www.youtube.com/watch?v=XSGBVzeBUbk`

## ✅ Solution
 - This PR adds an optional `add` Boolean query parameter to the  `iina://` URL scheme.
 - Setting `add=true` enqueues the URL in the current playlist.
 - Omitting `add` or setting `add=false` results in the familiar behavior.
 - Example URL:
  `iina://weblink?url=https://www.youtube.com/watch?v=XSGBVzeBUbk&add=true`

## 🗂 Type
 - [x] 🍾 Feature

## 🔥 Severity
- [x] 💎 Non-Breaking Changes

## 👨‍🎓 Implementation
 - [x] Full compatibility with all current usages of the `iina://` URL Scheme

## 🛃 Tests
 - [x] Tested on macOS 10.13
 - [x] Tested on macOS 10.14 Beta

