### PR TITLE
Fix a division by zero which is undefined behaviour

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -119,7 +119,10 @@ return -1;\
 
   // Get the codec context for the video stream
   AVStream *pVideoStream = pFormatCtx->streams[videoStream];
-  if (av_q2d(pVideoStream->avg_frame_rate) == 0) {
+  AVRational videoAvgFrameRate = pVideoStream->avg_frame_rate;
+
+  // Check whether the denominator (AVRational.den) is zero to prevent division-by-zero
+  if (videoAvgFrameRate.den == 0 || av_q2d(videoAvgFrameRate) == 0) {
     NSLog(@"Avg frame rate = 0, ignore");
     return -1;
   }


### PR DESCRIPTION
The current code in `FFmpegController.m` triggers undefined behavior with ogg-vorbis files which have embedded art-covers.

The problematic line can be found here:

https://github.com/lhc70000/iina/blob/e909cfdc406292c9ac57843a3dd77f1e60929a17/iina/FFmpegController.m#L122

If someone opens an ogg-vobis file which has an embedded covert-art, libavformat will set `avg_frame_rate` to zero by setting both the numerator and denominator to zero.

By looking at the definition of `av_q2d` we can see that it's a simple division and hence triggers undefine behaviour when both values are zero:

```c
static inline double av_q2d(AVRational a){
    return a.num / (double) a.den;
}
```

This issue actually came up when I tried to open an ogg-vorbis file which had an embedded cover-art but iina crashed everytime. It seems that the `avg_frame_rate` check triggered undefined behaviour which resulted in not triggering the condition of the if statement, therefor trying to read and decode video frames fails.

This small patch fixes this by checking if the denominator is null before invoking `av_q2d`.