### PR TITLE
[URL Scheme] Support `enqueue` Query Parameter 

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -371,7 +371,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       } else {
         player = PlayerCore.newPlayerCore
       }
-      player.openURLString(urlValue)
+
+      // enqueue
+      if let enqueueValue = queryDict["enqueue"], enqueueValue == "1", !PlayerCore.lastActive.info.playlist.isEmpty {
+        PlayerCore.lastActive.addToPlaylist(urlValue)
+        PlayerCore.lastActive.postNotification(.iinaPlaylistChanged)
+        PlayerCore.lastActive.sendOSD(.addToPlaylist(1))
+      } else {
+        player.openURLString(urlValue)
+      }
 
       // presentation options
       if let fsValue = queryDict["full_screen"], fsValue == "1" {

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -337,6 +337,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
    __/open__
    - `url`: a url or string to open.
    - `new_window`: 0 or 1 (default) to indicate whether open the media in a new window.
+   - `enqueue`: 0 (default) or 1 to indicate whether to add the media to the current playlist.
    - `full_screen`: 0 (default) or 1 to indicate whether open the media and enter fullscreen.
    - `pip`: 0 (default) or 1 to indicate whether open the media and enter pip.
    - `mpv_*`: additional mpv options to be passed. e.g. `mpv_volume=20`.


### PR DESCRIPTION
## 📋  Description
 - this PR adds the `enqueue` query parameter for usage via IINAs URL Scheme
 - the change has been discussed with @lhc70000
 - this PR branches off the current work being done within #1935

## 👨‍ Implementation
 - per default, `enqueue` is off (set to `0`) and does not change the IINA's familiar behavior of clearing the playlist upon opening an URL
 - if `enqueue` is active (set to `1`), URLs supplied via the URL scheme will be added to the current playlist, with the playlist UI updating automatically.
 - for the parameter to take effect, at least one existing playlist item is required
 - the right `PlayerCore` instance is resolved via `PlayerCore.lastActive`, this has been proven to be stable and performant

## 🔥 Example URLs
- `iina://weblink?url=https://test.com/movie.mp4&enqueue=1`
- `iina://weblink?url=https://www.youtube.com/watch?v=1nzCeB9sjWk&enqueue=1`

## 🛃 Tests
I have been using my previous implementation (#1872) for weeks without fail in correspondence with  the [Open with IINA](https://addons.mozilla.org/en-US/firefox/addon/open-with-iina/) web extension.

