### PR TITLE
[BUGFIX] Fixes YouTube Playlist Item Dragging and Reordering

### DIFF
--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -210,7 +210,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
         var oldIndexOffset = 0
         var newIndexOffset = 0
 
-        // Supports multi-line drag & drop (https://goo.gl/cRUvuH)
+        // Drag & Drop list items (multiline), https://goo.gl/cRUvuH
         for oldIndex in indexSet {
           if oldIndex < row {
             player.playlistMove(oldIndex + oldIndexOffset, to: row)
@@ -219,7 +219,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
             player.playlistMove(oldIndex, to: row + newIndexOffset)
             newIndexOffset += 1
           }
-          Logger.log("Playlist drag & drop: \(oldIndex) -->  \(row)")
+          Logger.log("Playlist Drag & Drop from \(oldIndex) to \(row)")
         }
       }
     } else if let paths = pasteboard.propertyList(forType: .nsFilenames) as? [String] {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -207,44 +207,20 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       if let rowData = pasteboard.data(forType: .iinaPlaylistItem) {
         let indexSet = NSKeyedUnarchiver.unarchiveObject(with: rowData) as! IndexSet
 
-        let playlistCount = player.info.playlist.count
-        var order: [Int] = Array(0..<playlistCount)
-        var droppedRow = row
-        let reversedIndexSet = indexSet.reversed()
+        var oldIndexOffset = 0
+        var newIndexOffset = 0
 
-        for selectedRow in reversedIndexSet {
-          if selectedRow < row {
-            droppedRow -= 1
+        // Supports multi-line drag & drop (https://goo.gl/cRUvuH)
+        for oldIndex in indexSet {
+          if oldIndex < row {
+            player.playlistMove(oldIndex + oldIndexOffset, to: row)
+            oldIndexOffset -= 1
+          } else {
+            player.playlistMove(oldIndex, to: row + newIndexOffset)
+            newIndexOffset += 1
           }
-          order.remove(at: selectedRow)
+          Logger.log("Playlist drag & drop: \(oldIndex) -->  \(row)")
         }
-
-        for selectedRow in reversedIndexSet {
-          order.insert(selectedRow, at: droppedRow)
-        }
-
-        let fileList = player.info.playlist.map { $0.filename }
-        var current: Int?
-        for i in 0..<playlistCount {
-          if player.info.playlist[i].isCurrent {
-            current = i
-            continue
-          }
-        }
-        player.clearPlaylist()
-
-        var before: [String] = []
-        var after: [String] = []
-        var foundCurrent = false
-        for position in order {
-          if position == current! {
-            foundCurrent = true
-            continue
-          }
-          foundCurrent ? after.append(fileList[position]) : before.append(fileList[position])
-        }
-        player.addToPlaylist(paths: after, at: 1)
-        player.addToPlaylist(paths: before, at: 0)
       }
     } else if let paths = pasteboard.propertyList(forType: .nsFilenames) as? [String] {
       let playableFiles = Utility.resolveURLs(player.getPlayableFiles(in: paths.map{ URL(fileURLWithPath: $0) }))


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.
---
### 🛃 Issue Description
- Currently, dragging / reordering any item within playlists loaded from YouTube result in the loss of all items' names , as they are reset to their internal `youtube-dl` id (e.g., `ytdl://PHov9j`), rendering the playlist unusable without warning.
 - When dropping local media files onto a YouTube playlists, reordering the local items also results in the loss of all YouTube file titles.
 - Playlist item names should remain intact, regardless of their source or of any dragging operation.
   
   
### 🚀 Solution Implementation
 - This PR updates the logic for dragging/reordering items within playlists.
 - By directly interfacing with MPVs native playlist sorting method (via `player.playlistMove`), the code is simplified, the internal playlist and UI are kept in sync, and items show their correct attributes.
 - Multi-line drag & drop operations are supported as well.
   
   
### 🖼 Demo

| ![before](https://user-images.githubusercontent.com/1630917/44962263-d955ee80-af1d-11e8-9b05-dd69e779ea6b.gif)  | ![after](https://user-images.githubusercontent.com/1630917/44962445-d3154180-af20-11e8-96f9-16a42c6ba5b8.gif) |
|:---:|:---:|
| before | after |
   
   
## 🗂 Type
Bugfix    
   
   
## 🔥 Severity
Non-Breaking   
   
   
## 🛃 Tests
Changes have been tested manually on macOS 10.13, 10.14 Developer Beta 9.