### PR TITLE
Add support for auto select ICC profile

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -698,7 +698,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       self.cachedScreenCount = screenCount
       self.videoView.updateDisplaylink()
     }
-
   }
 
   deinit {

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -34,6 +34,9 @@ class VideoView: NSView {
   var lastMousePosition: NSPoint?
 
   var hasPlayableFiles: Bool = false
+  
+  // cached indicator to prevent unnecessary updates of DisplayLink
+  var currentDisplay: UInt32?
 
   // MARK: - Attributes
 
@@ -177,11 +180,16 @@ class VideoView: NSView {
   func updateDisplaylink() {
     guard let window = window, let link = link else { return }
     let displayId = window.screen!.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! UInt32
+    if (currentDisplay == displayId) {
+      return
+    }
+    
     CVDisplayLinkSetCurrentCGDisplay(link, displayId)
     if let refreshRate = CGDisplayCopyDisplayMode(displayId)?.refreshRate {
       player.mpv.setDouble(MPVOption.Video.displayFps, refreshRate)
     }
     setICCProfile(displayId)
+    currentDisplay = displayId
   }
   
   func setICCProfile(_ displayId: UInt32) {

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -181,8 +181,39 @@ class VideoView: NSView {
     if let refreshRate = CGDisplayCopyDisplayMode(displayId)?.refreshRate {
       player.mpv.setDouble(MPVOption.Video.displayFps, refreshRate)
     }
+    
+    setICCProfile()
   }
-
+  
+  func setICCProfile() {
+    let deviceID = self.window?.screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! NSNumber
+    let uuid = CGDisplayCreateUUIDFromDisplayID(deviceID.uint32Value).takeRetainedValue()
+    
+    var argResult = (uuid, "")
+    let data_ptr = UnsafeMutablePointer(&argResult)
+    
+    ColorSyncIterateDeviceProfiles({ (dict: CFDictionary?, ptr: UnsafeMutableRawPointer?) -> Bool in
+      if let info = dict as? [String: Any], let current = info["DeviceProfileIsCurrent"] as? Int {
+        let deviceID = info["DeviceID"] as! CFUUID
+        let ptr = ptr!.bindMemory(to: (CFUUID, String).self, capacity: 1)
+        let uuid = ptr.pointee.0
+        
+        if current == 1, deviceID == uuid {
+          let profileURL = info["DeviceProfileURL"] as! URL
+          
+          ptr.pointee.1 = profileURL.absoluteString
+          
+          return false
+        }
+      }
+      
+      return true
+    }, data_ptr)
+    
+    if let iccProfilePath = URL(string: argResult.1)?.path, FileManager.default.fileExists(atPath: iccProfilePath) {
+      self.player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, iccProfilePath)
+    }
+  }
 }
 
 fileprivate func displayLinkCallback(


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It (should) fixes issue #888, #1673 and all colorspace-related issues.

---

**Description:**
This PR would read current device ICC profile path and set `icc-profile` attribute in `mpv` to support correct color transformation.