### PR TITLE
Fix nil unwrap on display configuration change

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -197,7 +197,7 @@ class VideoView: NSView {
   func setICCProfile(_ displayId: UInt32) {
     typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
 
-    let uuid = CGDisplayCreateUUIDFromDisplayID(displayId).takeRetainedValue()
+    guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else { return }
     var argResult: ProfileData = (uuid, nil)
     let dataPointer = UnsafeMutablePointer(&argResult)
 


### PR DESCRIPTION
When unplugging an external display while IINA is playing in fullscreen on a secondary display (not the one with Dock), two NSWindowDidChangeScreenNotification are sent in short succession. When receiving the first, CGDisplayCreateUUIDFromDisplayID will return nil for that window's screen, resulting in a crash.

- [x] This change has been discussed with the author.